### PR TITLE
Expand error code mapper coverage

### DIFF
--- a/src/core/multiplayer/error_code_mapper.cpp
+++ b/src/core/multiplayer/error_code_mapper.cpp
@@ -10,15 +10,155 @@
 
 namespace Core::Multiplayer::HLE {
 
+namespace {
+// Multiplayer Error -> LDN Result mappings
+static const std::unordered_map<ErrorCode, Service::LDN::Result> multiplayer_to_ldn_map_{
+    {ErrorCode::Success, Service::LDN::ResultSuccess},
+
+    // Connection errors
+    {ErrorCode::ConnectionFailed, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::ConnectionTimeout, Service::LDN::ResultAuthenticationTimeout},
+    {ErrorCode::ConnectionRefused, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::ConnectionLost, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::AuthenticationFailed, Service::LDN::ResultAuthenticationFailed},
+    {ErrorCode::AlreadyConnected, Service::LDN::ResultBadState},
+    {ErrorCode::NotConnected, Service::LDN::ResultBadState},
+
+    // Room errors
+    {ErrorCode::RoomNotFound, Service::LDN::ResultLocalCommunicationIdNotFound},
+    {ErrorCode::RoomFull, Service::LDN::ResultMaximumNodeCount},
+    {ErrorCode::RoomPasswordRequired, Service::LDN::ResultAuthenticationFailed},
+    {ErrorCode::InvalidRoomPassword, Service::LDN::ResultAuthenticationFailed},
+    {ErrorCode::AlreadyInRoom, Service::LDN::ResultBadState},
+    {ErrorCode::NotInRoom, Service::LDN::ResultBadState},
+
+    // Message errors
+    {ErrorCode::MessageTooLarge, Service::LDN::ResultAdvertiseDataTooLarge},
+    {ErrorCode::MessageTimeout, Service::LDN::ResultAuthenticationTimeout},
+    {ErrorCode::InvalidMessage, Service::LDN::ResultBadInput},
+    {ErrorCode::MessageQueueFull, Service::LDN::ResultInvalidBufferCount},
+
+    // General errors
+    {ErrorCode::InvalidParameter, Service::LDN::ResultBadInput},
+    {ErrorCode::InternalError, Service::LDN::ResultInternalError},
+    {ErrorCode::NetworkError, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::NetworkTimeout, Service::LDN::ResultAuthenticationTimeout},
+    {ErrorCode::HostUnreachable, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::InvalidResponse, Service::LDN::ResultBadInput},
+    {ErrorCode::SSLError, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::Timeout, Service::LDN::ResultAuthenticationTimeout},
+    {ErrorCode::NotSupported, Service::LDN::ResultDisabled},
+    {ErrorCode::PermissionDenied, Service::LDN::ResultAccessPointConnectionFailed},
+
+    // State errors
+    {ErrorCode::NotInitialized, Service::LDN::ResultBadState},
+    {ErrorCode::InvalidState, Service::LDN::ResultBadState},
+
+    // Discovery errors
+    {ErrorCode::DiscoveryFailed, Service::LDN::ResultConnectionFailed},
+    {ErrorCode::ServiceUnavailable, Service::LDN::ResultDisabled},
+
+    // Peer errors
+    {ErrorCode::MaxPeersExceeded, Service::LDN::ResultMaximumNodeCount},
+
+    // Protocol errors
+    {ErrorCode::ProtocolError, Service::LDN::ResultBadInput},
+
+    // Resource errors
+    {ErrorCode::ResourceExhausted, Service::LDN::ResultInvalidBufferCount},
+
+    // Platform-specific errors
+    {ErrorCode::PlatformAPIError, Service::LDN::ResultInternalError},
+    {ErrorCode::PlatformFeatureUnavailable, Service::LDN::ResultDisabled},
+    {ErrorCode::PlatformPermissionDenied, Service::LDN::ResultAccessPointConnectionFailed},
+
+    // Configuration errors
+    {ErrorCode::ConfigurationInvalid, Service::LDN::ResultBadInput},
+    {ErrorCode::ConfigurationMissing, Service::LDN::ResultBadInput},
+};
+
+// Generate reverse mapping from LDN Result -> ErrorCode
+static const std::unordered_map<Service::LDN::Result, ErrorCode> ldn_to_multiplayer_map_ = [] {
+    std::unordered_map<Service::LDN::Result, ErrorCode> map;
+    for (const auto& [mp_error, ldn_result] : multiplayer_to_ldn_map_) {
+        map.emplace(ldn_result, mp_error);
+    }
+    return map;
+}();
+
+// Human readable descriptions for multiplayer errors
+static const std::unordered_map<ErrorCode, std::string> error_descriptions_{
+    {ErrorCode::Success, "Operation completed successfully"},
+    {ErrorCode::ConnectionFailed, "Failed to establish network connection"},
+    {ErrorCode::ConnectionTimeout, "Connection attempt timed out"},
+    {ErrorCode::ConnectionRefused, "Connection was refused by remote host"},
+    {ErrorCode::ConnectionLost, "Network connection was lost"},
+    {ErrorCode::AuthenticationFailed, "Authentication with remote host failed"},
+    {ErrorCode::AlreadyConnected, "Already connected to a network"},
+    {ErrorCode::NotConnected, "Not connected to any network"},
+    {ErrorCode::RoomNotFound, "Requested room or session not found"},
+    {ErrorCode::RoomFull, "Room has reached maximum player capacity"},
+    {ErrorCode::RoomPasswordRequired, "Room requires password for access"},
+    {ErrorCode::InvalidRoomPassword, "Provided room password is incorrect"},
+    {ErrorCode::AlreadyInRoom, "Already joined a room or session"},
+    {ErrorCode::NotInRoom, "Not currently in any room or session"},
+    {ErrorCode::MessageTooLarge, "Message exceeds maximum allowed size"},
+    {ErrorCode::MessageTimeout, "Message transmission timed out"},
+    {ErrorCode::InvalidMessage, "Received message has invalid format"},
+    {ErrorCode::MessageQueueFull, "Message queue is full, cannot accept more messages"},
+    {ErrorCode::InvalidParameter, "One or more parameters are invalid"},
+    {ErrorCode::InternalError, "Internal system error occurred"},
+    {ErrorCode::NetworkError, "General network communication error"},
+    {ErrorCode::NetworkTimeout, "Network operation timed out"},
+    {ErrorCode::HostUnreachable, "Remote host is unreachable"},
+    {ErrorCode::InvalidResponse, "Received invalid response from remote host"},
+    {ErrorCode::SSLError, "SSL/TLS encryption error"},
+    {ErrorCode::Timeout, "Operation timed out"},
+    {ErrorCode::NotSupported, "Operation not supported on this platform"},
+    {ErrorCode::PermissionDenied, "Permission denied for requested operation"},
+    {ErrorCode::NotInitialized, "System not initialized"},
+    {ErrorCode::InvalidState, "System is in invalid state for this operation"},
+    {ErrorCode::DiscoveryFailed, "Network discovery failed"},
+    {ErrorCode::ServiceUnavailable, "Required service is unavailable"},
+    {ErrorCode::MaxPeersExceeded, "Maximum number of peers exceeded"},
+    {ErrorCode::ProtocolError, "Network protocol error"},
+    {ErrorCode::ResourceExhausted, "System resources exhausted"},
+    {ErrorCode::PlatformAPIError, "Platform-specific API error"},
+    {ErrorCode::PlatformFeatureUnavailable, "Required platform feature unavailable"},
+    {ErrorCode::PlatformPermissionDenied, "Platform permission denied"},
+    {ErrorCode::ConfigurationInvalid, "Configuration is invalid"},
+    {ErrorCode::ConfigurationMissing, "Required configuration is missing"},
+};
+
+// Human readable descriptions for LDN results
+static const std::unordered_map<Service::LDN::Result, std::string> ldn_result_descriptions_{
+    {Service::LDN::ResultSuccess, "LDN operation completed successfully"},
+    {Service::LDN::ResultAdvertiseDataTooLarge, "Advertise data exceeds maximum size"},
+    {Service::LDN::ResultAuthenticationFailed, "LDN authentication failed"},
+    {Service::LDN::ResultDisabled, "LDN service is disabled"},
+    {Service::LDN::ResultAirplaneModeEnabled, "Airplane mode is enabled"},
+    {Service::LDN::ResultInvalidNodeCount, "Invalid node count specified"},
+    {Service::LDN::ResultConnectionFailed, "LDN connection failed"},
+    {Service::LDN::ResultBadState, "LDN service is in bad state"},
+    {Service::LDN::ResultNoIpAddress, "No IP address available"},
+    {Service::LDN::ResultInvalidBufferCount, "Invalid buffer count"},
+    {Service::LDN::ResultAccessPointConnectionFailed, "Access point connection failed"},
+    {Service::LDN::ResultAuthenticationTimeout, "LDN authentication timed out"},
+    {Service::LDN::ResultMaximumNodeCount, "Maximum node count reached"},
+    {Service::LDN::ResultBadInput, "Invalid input provided to LDN service"},
+    {Service::LDN::ResultLocalCommunicationIdNotFound, "Local communication ID not found"},
+    {Service::LDN::ResultLocalCommunicationVersionTooLow, "Local communication version too low"},
+    {Service::LDN::ResultLocalCommunicationVersionTooHigh, "Local communication version too high"},
+    {Service::LDN::ResultInternalError, "Internal LDN error occurred"},
+};
+} // namespace
+
 /**
  * Concrete Error Code Mapper Implementation
- * Minimal implementation to make tests pass
  */
 class ConcreteErrorCodeMapper : public ErrorCodeMapper {
 public:
-    ConcreteErrorCodeMapper() {
-        InitializeErrorMappings();
-    }
+    ConcreteErrorCodeMapper() = default;
     
     Service::LDN::Result MapToLdnResult(ErrorCode error) override {
         auto it = multiplayer_to_ldn_map_.find(error);
@@ -107,59 +247,6 @@ public:
             return std::chrono::milliseconds(0);  // No retry
         }
     }
-
-private:
-    void InitializeErrorMappings() {
-        // Minimal mapping to make tests pass
-        // Full mapping will be implemented as needed
-        multiplayer_to_ldn_map_ = {
-            {ErrorCode::Success, ResultSuccess},
-            {ErrorCode::ConnectionFailed, Service::LDN::ResultConnectionFailed},
-            {ErrorCode::ConnectionTimeout, Service::LDN::ResultAuthenticationTimeout},
-            {ErrorCode::AuthenticationFailed, Service::LDN::ResultAuthenticationFailed},
-            {ErrorCode::MessageTooLarge, Service::LDN::ResultAdvertiseDataTooLarge},
-            {ErrorCode::InvalidParameter, Service::LDN::ResultBadInput},
-            {ErrorCode::InvalidState, Service::LDN::ResultBadState},
-            {ErrorCode::MaxPeersExceeded, Service::LDN::ResultMaximumNodeCount},
-            {ErrorCode::InternalError, Service::LDN::ResultInternalError}
-        };
-        
-        // Create reverse mapping
-        for (const auto& pair : multiplayer_to_ldn_map_) {
-            ldn_to_multiplayer_map_[pair.second] = pair.first;
-        }
-        
-        // Minimal error descriptions
-        error_descriptions_ = {
-            {ErrorCode::Success, "Operation completed successfully"},
-            {ErrorCode::ConnectionFailed, "Failed to establish network connection"},
-            {ErrorCode::ConnectionTimeout, "Connection attempt timed out"},
-            {ErrorCode::AuthenticationFailed, "Authentication with remote host failed"},
-            {ErrorCode::MessageTooLarge, "Message exceeds maximum allowed size"},
-            {ErrorCode::InvalidParameter, "One or more parameters are invalid"},
-            {ErrorCode::InvalidState, "System is in invalid state for this operation"},
-            {ErrorCode::MaxPeersExceeded, "Maximum number of peers exceeded"},
-            {ErrorCode::InternalError, "Internal system error occurred"}
-        };
-        
-        // Minimal LDN result descriptions
-        ldn_result_descriptions_ = {
-            {Service::LDN::ResultSuccess, "LDN operation completed successfully"},
-            {Service::LDN::ResultConnectionFailed, "LDN connection failed"},
-            {Service::LDN::ResultAuthenticationTimeout, "LDN authentication timed out"},
-            {Service::LDN::ResultAuthenticationFailed, "LDN authentication failed"},
-            {Service::LDN::ResultAdvertiseDataTooLarge, "Advertise data exceeds maximum size"},
-            {Service::LDN::ResultBadInput, "Invalid input provided to LDN service"},
-            {Service::LDN::ResultBadState, "LDN service is in bad state"},
-            {Service::LDN::ResultMaximumNodeCount, "Maximum node count reached"},
-            {Service::LDN::ResultInternalError, "Internal LDN error occurred"}
-        };
-    }
-    
-    std::unordered_map<ErrorCode, Service::LDN::Result> multiplayer_to_ldn_map_;
-    std::unordered_map<Service::LDN::Result, ErrorCode> ldn_to_multiplayer_map_;
-    std::unordered_map<ErrorCode, std::string> error_descriptions_;
-    std::unordered_map<Service::LDN::Result, std::string> ldn_result_descriptions_;
 };
 
 } // namespace Core::Multiplayer::HLE


### PR DESCRIPTION
## Summary
- cover all multiplayer ErrorCodes by mapping them to corresponding LDN results
- generate LDN->multiplayer lookup from mapping and keep tables static
- provide detailed descriptions for multiplayer errors and LDN results

## Testing
- `cmake -S tests -B build` *(failed: Could not find a package configuration file provided by "GTest"...)*

------
https://chatgpt.com/codex/tasks/task_e_689510ab9c408322853e0234dddc63f6