### PR TITLE
Implement backend factory for multiplayer

### DIFF
--- a/src/core/multiplayer/backend_factory.cpp
+++ b/src/core/multiplayer/backend_factory.cpp
@@ -5,6 +5,11 @@
 
 #include <memory>
 
+#include "model_a/model_a_backend.h"
+#include "model_a/p2p_network_factory.h"
+#include "model_b/model_b_backend.h"
+#include "model_b/mdns_discovery.h"
+
 namespace Core::Multiplayer::HLE {
 
 /**
@@ -17,15 +22,18 @@ public:
         : config_manager_(config) {}
     
     std::unique_ptr<MultiplayerBackend> CreateBackend(BackendType type) override {
-        // Minimal implementation - returns nullptr to make tests fail appropriately
-        // This will be replaced with actual backend implementations
         switch (type) {
-        case BackendType::ModelA_Internet:
-            // return std::make_unique<ModelABackend>();
-            return nullptr;  // Will cause tests to fail as expected
-        case BackendType::ModelB_AdHoc:
-            // return std::make_unique<ModelBBackend>();
-            return nullptr;  // Will cause tests to fail as expected
+        case BackendType::ModelA_Internet: {
+            auto p2p_network = ModelA::P2PNetworkFactory::Create(
+                ModelA::P2PNetworkFactory::GetDefaultImplementation(),
+                ModelA::P2PNetworkConfig{}
+            );
+            return std::make_unique<ModelA::ModelABackend>(config_manager_, std::move(p2p_network));
+        }
+        case BackendType::ModelB_AdHoc: {
+            auto discovery = std::make_shared<ModelB::MdnsDiscovery>(nullptr, nullptr, nullptr);
+            return std::make_unique<ModelB::ModelBBackend>(config_manager_, discovery);
+        }
         default:
             return nullptr;
         }
@@ -40,15 +48,16 @@ public:
         case ConfigurationManager::MultiplayerMode::AdHoc:
             return BackendType::ModelB_AdHoc;
         case ConfigurationManager::MultiplayerMode::Auto:
-            // Auto-select based on availability
-            if (config_manager_->IsModelBAvailable()) {
-                return BackendType::ModelB_AdHoc;  // Prefer local play
-            } else if (config_manager_->IsModelAAvailable()) {
-                return BackendType::ModelA_Internet;
-            } else {
-                // Fallback to internet mode
+            if (config_manager_->IsModelBAvailable() && ModelB::ModelBBackend::IsSupported()) {
+                return BackendType::ModelB_AdHoc;
+            }
+            if (config_manager_->IsModelAAvailable() && ModelA::ModelABackend::IsSupported()) {
                 return BackendType::ModelA_Internet;
             }
+            if (ModelA::ModelABackend::IsSupported()) {
+                return BackendType::ModelA_Internet;
+            }
+            return BackendType::ModelB_AdHoc;
         default:
             return BackendType::ModelA_Internet;
         }

--- a/src/core/multiplayer/model_a/CMakeLists.txt
+++ b/src/core/multiplayer/model_a/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SOURCES
     p2p_network_factory.cpp
     relay_protocol.cpp
     relay_client.cpp
+    model_a_backend.cpp
 )
 
 set(HEADERS
@@ -51,6 +52,7 @@ set(HEADERS
     i_relay_client.h
     relay_protocol.h
     relay_client.h
+    model_a_backend.h
 )
 
 add_library(sudachi_multiplayer_model_a STATIC ${SOURCES} ${HEADERS})

--- a/src/core/multiplayer/model_a/model_a_backend.cpp
+++ b/src/core/multiplayer/model_a/model_a_backend.cpp
@@ -1,0 +1,94 @@
+#include "model_a_backend.h"
+
+namespace Core::Multiplayer::ModelA {
+
+bool ModelABackend::IsSupported() {
+    return true;
+}
+
+ModelABackend::ModelABackend(std::shared_ptr<HLE::ConfigurationManager> config,
+                             std::unique_ptr<IP2PNetwork> network)
+    : config_(std::move(config)), network_(std::move(network)) {}
+
+ErrorCode ModelABackend::Initialize() {
+    initialized_ = true;
+    return ErrorCode::Success;
+}
+
+ErrorCode ModelABackend::Finalize() {
+    initialized_ = false;
+    return ErrorCode::Success;
+}
+
+bool ModelABackend::IsInitialized() const {
+    return initialized_;
+}
+
+ErrorCode ModelABackend::CreateNetwork(const Service::LDN::CreateNetworkConfig&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::DestroyNetwork() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::Connect(const Service::LDN::ConnectNetworkData&,
+                                 const Service::LDN::NetworkInfo&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::Disconnect() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::Scan(std::vector<Service::LDN::NetworkInfo>&,
+                              const Service::LDN::ScanFilter&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::GetNetworkInfo(Service::LDN::NetworkInfo&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::GetCurrentState(Service::LDN::State&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::OpenAccessPoint() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::CloseAccessPoint() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::OpenStation() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::CloseStation() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::SendPacket(const std::vector<uint8_t>&, uint8_t) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::ReceivePacket(std::vector<uint8_t>&, uint8_t&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::SetAdvertiseData(const std::vector<uint8_t>&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::GetSecurityParameter(Service::LDN::SecurityParameter&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::GetDisconnectReason(Service::LDN::DisconnectReason&) {
+    return ErrorCode::NotImplemented;
+}
+
+} // namespace Core::Multiplayer::ModelA
+

--- a/src/core/multiplayer/model_a/model_a_backend.h
+++ b/src/core/multiplayer/model_a/model_a_backend.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <cstdint>
+
+#include "core/multiplayer/multiplayer_backend.h"
+#include "i_p2p_network.h"
+
+namespace Core::Multiplayer::ModelA {
+
+class ModelABackend : public HLE::MultiplayerBackend {
+public:
+    static bool IsSupported();
+
+    ModelABackend(std::shared_ptr<HLE::ConfigurationManager> config,
+                  std::unique_ptr<IP2PNetwork> network);
+
+    ErrorCode Initialize() override;
+    ErrorCode Finalize() override;
+    bool IsInitialized() const override;
+
+    ErrorCode CreateNetwork(const Service::LDN::CreateNetworkConfig& config) override;
+    ErrorCode DestroyNetwork() override;
+    ErrorCode Connect(const Service::LDN::ConnectNetworkData& connect_data,
+                      const Service::LDN::NetworkInfo& network_info) override;
+    ErrorCode Disconnect() override;
+
+    ErrorCode Scan(std::vector<Service::LDN::NetworkInfo>& out_networks,
+                   const Service::LDN::ScanFilter& filter) override;
+    ErrorCode GetNetworkInfo(Service::LDN::NetworkInfo& out_info) override;
+    ErrorCode GetCurrentState(Service::LDN::State& out_state) override;
+
+    ErrorCode OpenAccessPoint() override;
+    ErrorCode CloseAccessPoint() override;
+    ErrorCode OpenStation() override;
+    ErrorCode CloseStation() override;
+
+    ErrorCode SendPacket(const std::vector<uint8_t>& data, uint8_t node_id) override;
+    ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) override;
+
+    ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) override;
+    ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) override;
+    ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) override;
+
+private:
+    std::shared_ptr<HLE::ConfigurationManager> config_;
+    std::unique_ptr<IP2PNetwork> network_;
+    bool initialized_ {false};
+};
+
+} // namespace Core::Multiplayer::ModelA
+

--- a/src/core/multiplayer/model_b/CMakeLists.txt
+++ b/src/core/multiplayer/model_b/CMakeLists.txt
@@ -5,12 +5,14 @@ set(SOURCES
     # mDNS Discovery implementation
     mdns_discovery.cpp
     mdns_txt_records.cpp
+    model_b_backend.cpp
 )
 
 set(HEADERS
     # mDNS Discovery headers (interfaces defined for TDD red phase)
     mdns_discovery.h
     mdns_txt_records.h
+    model_b_backend.h
 )
 
 # Platform-specific sources

--- a/src/core/multiplayer/model_b/model_b_backend.cpp
+++ b/src/core/multiplayer/model_b/model_b_backend.cpp
@@ -1,0 +1,94 @@
+#include "model_b_backend.h"
+
+namespace Core::Multiplayer::ModelB {
+
+bool ModelBBackend::IsSupported() {
+    return true;
+}
+
+ModelBBackend::ModelBBackend(std::shared_ptr<HLE::ConfigurationManager> config,
+                             std::shared_ptr<MdnsDiscovery> discovery)
+    : config_(std::move(config)), discovery_(std::move(discovery)) {}
+
+ErrorCode ModelBBackend::Initialize() {
+    initialized_ = true;
+    return ErrorCode::Success;
+}
+
+ErrorCode ModelBBackend::Finalize() {
+    initialized_ = false;
+    return ErrorCode::Success;
+}
+
+bool ModelBBackend::IsInitialized() const {
+    return initialized_;
+}
+
+ErrorCode ModelBBackend::CreateNetwork(const Service::LDN::CreateNetworkConfig&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::DestroyNetwork() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::Connect(const Service::LDN::ConnectNetworkData&,
+                                 const Service::LDN::NetworkInfo&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::Disconnect() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::Scan(std::vector<Service::LDN::NetworkInfo>&,
+                              const Service::LDN::ScanFilter&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::GetNetworkInfo(Service::LDN::NetworkInfo&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::GetCurrentState(Service::LDN::State&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::OpenAccessPoint() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::CloseAccessPoint() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::OpenStation() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::CloseStation() {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::SendPacket(const std::vector<uint8_t>&, uint8_t) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::ReceivePacket(std::vector<uint8_t>&, uint8_t&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::SetAdvertiseData(const std::vector<uint8_t>&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::GetSecurityParameter(Service::LDN::SecurityParameter&) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::GetDisconnectReason(Service::LDN::DisconnectReason&) {
+    return ErrorCode::NotImplemented;
+}
+
+} // namespace Core::Multiplayer::ModelB
+

--- a/src/core/multiplayer/model_b/model_b_backend.h
+++ b/src/core/multiplayer/model_b/model_b_backend.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <cstdint>
+
+#include "core/multiplayer/multiplayer_backend.h"
+#include "mdns_discovery.h"
+
+namespace Core::Multiplayer::ModelB {
+
+class ModelBBackend : public HLE::MultiplayerBackend {
+public:
+    static bool IsSupported();
+
+    ModelBBackend(std::shared_ptr<HLE::ConfigurationManager> config,
+                  std::shared_ptr<MdnsDiscovery> discovery);
+
+    ErrorCode Initialize() override;
+    ErrorCode Finalize() override;
+    bool IsInitialized() const override;
+
+    ErrorCode CreateNetwork(const Service::LDN::CreateNetworkConfig& config) override;
+    ErrorCode DestroyNetwork() override;
+    ErrorCode Connect(const Service::LDN::ConnectNetworkData& connect_data,
+                      const Service::LDN::NetworkInfo& network_info) override;
+    ErrorCode Disconnect() override;
+
+    ErrorCode Scan(std::vector<Service::LDN::NetworkInfo>& out_networks,
+                   const Service::LDN::ScanFilter& filter) override;
+    ErrorCode GetNetworkInfo(Service::LDN::NetworkInfo& out_info) override;
+    ErrorCode GetCurrentState(Service::LDN::State& out_state) override;
+
+    ErrorCode OpenAccessPoint() override;
+    ErrorCode CloseAccessPoint() override;
+    ErrorCode OpenStation() override;
+    ErrorCode CloseStation() override;
+
+    ErrorCode SendPacket(const std::vector<uint8_t>& data, uint8_t node_id) override;
+    ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) override;
+
+    ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) override;
+    ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) override;
+    ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) override;
+
+private:
+    std::shared_ptr<HLE::ConfigurationManager> config_;
+    std::shared_ptr<MdnsDiscovery> discovery_;
+    bool initialized_ {false};
+};
+
+} // namespace Core::Multiplayer::ModelB
+


### PR DESCRIPTION
## Summary
- add concrete ModelA and ModelB backend stubs
- wire backend factory to create backends with their network dependencies
- select preferred backend based on config and runtime support

## Testing
- `cmake -DBUILD_TESTING=OFF ..` *(fails: HunterGate before project)*

------
https://chatgpt.com/codex/tasks/task_e_689510aa44888322bac1bffcb0511672