### PR TITLE
Refactor P2P network to wrap libp2p with async interface

### DIFF
--- a/src/core/multiplayer/model_a/i_p2p_network.h
+++ b/src/core/multiplayer/model_a/i_p2p_network.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <functional>
 #include <cstdint>
+#include <future>
 
 namespace Core::Multiplayer::ModelA {
 
@@ -29,7 +30,7 @@ public:
     };
 
     // Network lifecycle
-    virtual MultiplayerResult Start() = 0;
+    virtual std::future<MultiplayerResult> Start() = 0;
     virtual MultiplayerResult Stop() = 0;
     virtual MultiplayerResult Shutdown() = 0;
     virtual bool IsStarted() const = 0;
@@ -38,7 +39,7 @@ public:
     virtual std::string GetPeerId() const = 0;
 
     // Connection management
-    virtual MultiplayerResult ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) = 0;
+    virtual std::future<MultiplayerResult> ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) = 0;
     virtual MultiplayerResult DisconnectFromPeer(const std::string& peer_id) = 0;
     virtual bool IsConnectedToPeer(const std::string& peer_id) const = 0;
     virtual bool IsConnectedViaaRelay(const std::string& peer_id) const = 0;
@@ -52,7 +53,7 @@ public:
     virtual void HandleIncomingMessage(const std::string& peer_id, const std::string& protocol, const std::vector<uint8_t>& data) = 0;
 
     // NAT traversal
-    virtual MultiplayerResult DetectNATType() = 0;
+    virtual std::future<MultiplayerResult> DetectNATType() = 0;
     virtual bool CanTraverseNAT(NATType local_nat, NATType remote_nat) const = 0;
     virtual std::vector<std::string> GetTraversalStrategies(NATType local_nat, NATType remote_nat) const = 0;
 

--- a/src/core/multiplayer/model_a/libp2p_p2p_network.cpp
+++ b/src/core/multiplayer/model_a/libp2p_p2p_network.cpp
@@ -446,30 +446,37 @@ std::vector<std::string> Libp2pP2PNetwork::GetConfiguredRelayServers() const {
 
 // Callback setters
 void Libp2pP2PNetwork::SetOnPeerConnectedCallback(std::function<void(const std::string&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_peer_connected_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnPeerDisconnectedCallback(std::function<void(const std::string&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_peer_disconnected_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnConnectionFailedCallback(std::function<void(const std::string&, const std::string&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_connection_failed_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnMessageReceivedCallback(std::function<void(const std::string&, const std::string&, const std::vector<uint8_t>&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_message_received_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnNATDetectedCallback(std::function<void(NATType, bool)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_nat_detected_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnRelayConnectedCallback(std::function<void(const std::string&, const std::string&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_relay_connected_ = callback;
 }
 
 void Libp2pP2PNetwork::SetOnRelayFailedCallback(std::function<void(const std::string&, const std::string&)> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     on_relay_failed_ = callback;
 }
 

--- a/src/core/multiplayer/model_a/p2p_network.cpp
+++ b/src/core/multiplayer/model_a/p2p_network.cpp
@@ -2,385 +2,115 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "p2p_network.h"
-#include <stdexcept>
-#include <algorithm>
+#include "libp2p_p2p_network.h"
 #include <future>
-#include <chrono>
-
-#ifdef SUDACHI_TESTING_ENABLED
-#include "../tests/mock_libp2p.h"
-#endif
 
 namespace Core::Multiplayer::ModelA {
 
-#ifdef SUDACHI_TESTING_ENABLED
-P2PNetwork::P2PNetwork(
-    const P2PNetworkConfig& config,
-    std::shared_ptr<Test::MockLibp2pHost> host,
-    std::shared_ptr<Test::MockTransportManager> transport_manager,
-    std::shared_ptr<Test::MockSecurityManager> security_manager,
-    std::shared_ptr<Test::MockAutoNATService> autonat_service,
-    std::shared_ptr<Test::MockCircuitRelay> circuit_relay,
-    std::shared_ptr<Test::MockPerformanceMonitor> performance_monitor
-) : config_(config),
-    mock_host_(host),
-    mock_transport_manager_(transport_manager),
-    mock_security_manager_(security_manager),
-    mock_autonat_service_(autonat_service),
-    mock_circuit_relay_(circuit_relay),
-    mock_performance_monitor_(performance_monitor) {
-    
-    ValidateConfiguration();
-    
-    // Initialize transport configuration
-    if (config_.enable_tcp) {
-        mock_transport_manager_->addTransport("tcp", config_.tcp_port);
-    }
-    if (config_.enable_quic) {
-        mock_transport_manager_->addTransport("quic", config_.quic_port);
-    }
-    if (config_.enable_websocket) {
-        mock_transport_manager_->addTransport("websocket", config_.websocket_port);
-    }
-    
-    // Initialize security
-    mock_security_manager_->initializeNoise("");
-    
-    // Configure relay servers
-    for (const auto& relay : config_.relay_servers) {
-        mock_circuit_relay_->addRelayServer(relay);
-    }
-    
-    // Initialize NAT detection if enabled
-    if (config_.enable_autonat) {
-        mock_autonat_service_->detectNATType();
-    }
-}
-#endif
+P2PNetwork::P2PNetwork(const P2PNetworkConfig& config)
+    : impl_(std::make_unique<Libp2pP2PNetwork>(config)) {}
 
-P2PNetwork::P2PNetwork(const P2PNetworkConfig& config) : config_(config) {
-    // Production implementation would initialize real libp2p components here
-    // For now, this constructor is not implemented as tests use the mock version
-    throw std::runtime_error("Production P2PNetwork constructor not implemented yet");
+P2PNetwork::~P2PNetwork() = default;
+
+std::future<MultiplayerResult> P2PNetwork::Start() {
+    return std::async(std::launch::async, [this] { return impl_->Start(); });
 }
 
-MultiplayerResult P2PNetwork::Start() {
-#ifdef SUDACHI_TESTING_ENABLED
-    try {
-        mock_host_->start();
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
-#else
-    // Production implementation not available yet
-    throw std::runtime_error("Production P2P implementation not available yet");
-#endif
-}
+MultiplayerResult P2PNetwork::Stop() { return impl_->Stop(); }
 
-MultiplayerResult P2PNetwork::Stop() {
-    try {
-        mock_host_->stop();
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
-}
+MultiplayerResult P2PNetwork::Shutdown() { return impl_->Shutdown(); }
 
-MultiplayerResult P2PNetwork::Shutdown() {
-    try {
-        // Disconnect all peers
-        auto peers = mock_host_->getConnectedPeers();
-        for (const auto& peer_id : peers) {
-            mock_host_->disconnect(peer_id);
-        }
+bool P2PNetwork::IsStarted() const { return impl_->IsStarted(); }
 
-        // Stop the host
-        mock_host_->stop();
+std::string P2PNetwork::GetPeerId() const { return impl_->GetPeerId(); }
 
-        {
-            std::lock_guard<std::mutex> lock(state_mutex_);
-            // Clear state
-            connected_peers_.clear();
-            relay_connected_peers_.clear();
-        }
-
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
-}
-
-bool P2PNetwork::IsStarted() const {
-    return mock_host_->isStarted();
-}
-
-std::string P2PNetwork::GetPeerId() const {
-    return mock_host_->getId();
-}
-
-MultiplayerResult P2PNetwork::ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) {
-    // Check connection limit without holding state lock
-    if (mock_host_->getConnectionCount() >= config_.max_connections) {
-        return MultiplayerResult::ConnectionLimitReached;
-    }
-
-    // Try direct connection first
-    auto direct_result = AttemptDirectConnection(peer_id, multiaddr);
-    if (direct_result == MultiplayerResult::Success) {
-        return direct_result;
-    }
-
-    // Fall back to relay if enabled and direct connection failed
-    if (config_.enable_relay) {
-        return AttemptRelayConnection(peer_id);
-    }
-
-    return direct_result;
+std::future<MultiplayerResult> P2PNetwork::ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) {
+    return std::async(std::launch::async, [this, peer_id, multiaddr] {
+        return impl_->ConnectToPeer(peer_id, multiaddr);
+    });
 }
 
 MultiplayerResult P2PNetwork::DisconnectFromPeer(const std::string& peer_id) {
-    try {
-        if (mock_host_->isConnected(peer_id)) {
-            mock_host_->disconnect(peer_id);
-            {
-                std::lock_guard<std::mutex> lock(state_mutex_);
-                connected_peers_.erase(peer_id);
-                relay_connected_peers_.erase(peer_id);
-            }
-
-            if (on_peer_disconnected_) {
-                on_peer_disconnected_(peer_id);
-            }
-        }
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
+    return impl_->DisconnectFromPeer(peer_id);
 }
 
 bool P2PNetwork::IsConnectedToPeer(const std::string& peer_id) const {
-    return mock_host_->isConnected(peer_id);
+    return impl_->IsConnectedToPeer(peer_id);
 }
 
 bool P2PNetwork::IsConnectedViaaRelay(const std::string& peer_id) const {
-    return mock_circuit_relay_->isConnectedViaRelay(peer_id);
+    return impl_->IsConnectedViaaRelay(peer_id);
 }
 
-size_t P2PNetwork::GetConnectionCount() const {
-    return mock_host_->getConnectionCount();
-}
+size_t P2PNetwork::GetConnectionCount() const { return impl_->GetConnectionCount(); }
 
-std::vector<std::string> P2PNetwork::GetConnectedPeers() const {
-    return mock_host_->getConnectedPeers();
-}
+std::vector<std::string> P2PNetwork::GetConnectedPeers() const { return impl_->GetConnectedPeers(); }
 
 MultiplayerResult P2PNetwork::SendMessage(const std::string& peer_id, const std::string& protocol, const std::vector<uint8_t>& data) {
-    if (!mock_host_->isConnected(peer_id)) {
-        return MultiplayerResult::NotConnected;
-    }
-
-    try {
-        bool success = mock_host_->sendMessage(peer_id, protocol, data);
-        if (success) {
-            mock_performance_monitor_->recordMessageSent(peer_id, data.size());
-            return MultiplayerResult::Success;
-        }
-        return MultiplayerResult::NetworkError;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
+    return impl_->SendMessage(peer_id, protocol, data);
 }
 
 MultiplayerResult P2PNetwork::BroadcastMessage(const std::string& protocol, const std::vector<uint8_t>& data) {
-    try {
-        mock_host_->broadcast(protocol, data);
-
-        // Record metrics for all connected peers
-        auto peers = mock_host_->getConnectedPeers();
-        for (const auto& peer_id : peers) {
-            mock_performance_monitor_->recordMessageSent(peer_id, data.size());
-        }
-
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
+    return impl_->BroadcastMessage(protocol, data);
 }
 
 void P2PNetwork::RegisterProtocolHandler(const std::string& protocol) {
-    // Create a protocol handler that calls our HandleIncomingMessage
-    auto handler = [this](const std::string& peer_id, const std::vector<uint8_t>& data) {
-        // This would normally be called by libp2p, but for tests we simulate it
-        // The test manually calls HandleIncomingMessage
-    };
-
-    mock_host_->setProtocolHandler(protocol, handler);
-
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    protocol_handlers_[protocol] = handler;
+    impl_->RegisterProtocolHandler(protocol);
 }
 
 void P2PNetwork::HandleIncomingMessage(const std::string& peer_id, const std::string& protocol, const std::vector<uint8_t>& data) {
-    mock_performance_monitor_->recordMessageReceived(peer_id, data.size());
-    
-    if (on_message_received_) {
-        on_message_received_(peer_id, protocol, data);
-    }
+    impl_->HandleIncomingMessage(peer_id, protocol, data);
 }
 
-MultiplayerResult P2PNetwork::DetectNATType() {
-    try {
-        mock_autonat_service_->detectNATType();
-        
-        if (on_nat_detected_) {
-            // For TDD green phase, we'll simulate the call and conversion
-            // In real implementation, this would get the actual NAT type from the service
-            auto nat_type = NATType::FullCone; // Hardcoded for tests to pass
-            bool reachable = true; // Hardcoded for tests to pass
-            on_nat_detected_(nat_type, reachable);
-        }
-        
-        return MultiplayerResult::Success;
-    } catch (const std::exception&) {
-        return MultiplayerResult::NetworkError;
-    }
+std::future<MultiplayerResult> P2PNetwork::DetectNATType() {
+    return std::async(std::launch::async, [this] { return impl_->DetectNATType(); });
 }
 
 bool P2PNetwork::CanTraverseNAT(NATType local_nat, NATType remote_nat) const {
-    // For TDD green phase, provide hardcoded logic that makes tests pass
-    // In real implementation, this would use the mock service properly
-    return true; // Simplified for tests to pass
+    return impl_->CanTraverseNAT(local_nat, remote_nat);
 }
 
 std::vector<std::string> P2PNetwork::GetTraversalStrategies(NATType local_nat, NATType remote_nat) const {
-    // For TDD green phase, return hardcoded strategies that make tests pass
-    return {"hole_punch", "relay"};
+    return impl_->GetTraversalStrategies(local_nat, remote_nat);
 }
 
 std::vector<std::string> P2PNetwork::GetConfiguredRelayServers() const {
-    return mock_circuit_relay_->getRelayServers();
+    return impl_->GetConfiguredRelayServers();
 }
 
 void P2PNetwork::SetOnPeerConnectedCallback(std::function<void(const std::string&)> callback) {
-    on_peer_connected_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnPeerConnectedCallback(callback);
 }
 
 void P2PNetwork::SetOnPeerDisconnectedCallback(std::function<void(const std::string&)> callback) {
-    on_peer_disconnected_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnPeerDisconnectedCallback(callback);
 }
 
 void P2PNetwork::SetOnConnectionFailedCallback(std::function<void(const std::string&, const std::string&)> callback) {
-    on_connection_failed_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnConnectionFailedCallback(callback);
 }
 
 void P2PNetwork::SetOnMessageReceivedCallback(std::function<void(const std::string&, const std::string&, const std::vector<uint8_t>&)> callback) {
-    on_message_received_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnMessageReceivedCallback(callback);
 }
 
 void P2PNetwork::SetOnNATDetectedCallback(std::function<void(NATType, bool)> callback) {
-    on_nat_detected_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnNATDetectedCallback(callback);
 }
 
 void P2PNetwork::SetOnRelayConnectedCallback(std::function<void(const std::string&, const std::string&)> callback) {
-    on_relay_connected_ = callback;
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnRelayConnectedCallback(callback);
 }
 
 void P2PNetwork::SetOnRelayFailedCallback(std::function<void(const std::string&, const std::string&)> callback) {
-    on_relay_failed_ = callback;
-}
-
-void P2PNetwork::ValidateConfiguration() {
-    if (!config_.enable_tcp && !config_.enable_quic && !config_.enable_websocket) {
-        throw std::invalid_argument("At least one transport must be enabled");
-    }
-    
-    if (config_.max_connections == 0) {
-        throw std::invalid_argument("max_connections must be greater than 0");
-    }
-}
-
-P2PNetwork::NATType P2PNetwork::ConvertMockNATType(int mock_type) const {
-    // Map integer enum values to our NATType enum
-    // 0=UNKNOWN, 1=FULL_CONE, 2=RESTRICTED_CONE, 3=PORT_RESTRICTED_CONE, 4=SYMMETRIC, 5=NO_NAT
-    switch (mock_type) {
-        case 0: return NATType::Unknown;
-        case 1: return NATType::FullCone;
-        case 2: return NATType::RestrictedCone;
-        case 3: return NATType::PortRestrictedCone;
-        case 4: return NATType::Symmetric;
-        case 5: return NATType::NoNAT;
-        default: return NATType::Unknown;
-    }
-}
-
-int P2PNetwork::ConvertToMockNATType(NATType nat_type) const {
-    // Map our NATType enum to integer enum values
-    // 0=UNKNOWN, 1=FULL_CONE, 2=RESTRICTED_CONE, 3=PORT_RESTRICTED_CONE, 4=SYMMETRIC, 5=NO_NAT
-    switch (nat_type) {
-        case NATType::Unknown: return 0;
-        case NATType::FullCone: return 1;
-        case NATType::RestrictedCone: return 2;
-        case NATType::PortRestrictedCone: return 3;
-        case NATType::Symmetric: return 4;
-        case NATType::NoNAT: return 5;
-        default: return 0;
-    }
-}
-
-MultiplayerResult P2PNetwork::AttemptDirectConnection(const std::string& peer_id, const std::string& multiaddr) {
-    try {
-        mock_host_->connect(multiaddr);
-        {
-            std::lock_guard<std::mutex> lock(state_mutex_);
-            connected_peers_.insert(peer_id);
-        }
-
-        // Record performance metrics
-        auto connection_time = std::chrono::milliseconds(100); // Simulated connection time
-        mock_performance_monitor_->recordConnectionEstablished(peer_id, connection_time);
-
-        if (on_peer_connected_) {
-            on_peer_connected_(peer_id);
-        }
-        
-        return MultiplayerResult::Success;
-    } catch (const std::exception& e) {
-        if (on_connection_failed_) {
-            on_connection_failed_(peer_id, e.what());
-        }
-        return MultiplayerResult::NetworkError;
-    }
-}
-
-MultiplayerResult P2PNetwork::AttemptRelayConnection(const std::string& peer_id) {
-    try {
-        std::string relay_addr = mock_circuit_relay_->selectBestRelay(peer_id);
-        bool success = mock_circuit_relay_->connectViaRelay(peer_id, relay_addr);
-
-        if (success) {
-            {
-                std::lock_guard<std::mutex> lock(state_mutex_);
-                relay_connected_peers_.insert(peer_id);
-            }
-
-            if (on_relay_connected_) {
-                on_relay_connected_(peer_id, relay_addr);
-            }
-            
-            return MultiplayerResult::Success;
-        } else {
-            if (on_relay_failed_) {
-                on_relay_failed_(peer_id, "Relay connection failed");
-            }
-            return MultiplayerResult::NetworkError;
-        }
-    } catch (const std::exception& e) {
-        if (on_relay_failed_) {
-            on_relay_failed_(peer_id, e.what());
-        }
-        return MultiplayerResult::NetworkError;
-    }
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    impl_->SetOnRelayFailedCallback(callback);
 }
 
 } // namespace Core::Multiplayer::ModelA

--- a/src/core/multiplayer/model_a/p2p_network.h
+++ b/src/core/multiplayer/model_a/p2p_network.h
@@ -5,47 +5,26 @@
 
 #include "i_p2p_network.h"
 #include "p2p_types.h"
+#include <future>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
-#include <unordered_set>
-
-// Forward declarations for mock interfaces
-namespace Core::Multiplayer::ModelA::Test {
-class MockLibp2pHost;
-class MockTransportManager;
-class MockSecurityManager;
-class MockAutoNATService;
-class MockCircuitRelay;
-class MockPerformanceMonitor;
-}
 
 namespace Core::Multiplayer::ModelA {
 
+class Libp2pP2PNetwork; // forward declaration
+
 /**
- * P2P Network implementation using cpp-libp2p
- * Handles peer-to-peer connections, NAT traversal, and relay fallback
+ * High level P2P network facade.
+ * Wraps the Libp2pP2PNetwork implementation and exposes
+ * asynchronous operations.
  */
 class P2PNetwork : public IP2PNetwork {
 public:
-    // Constructor for dependency injection (primarily for testing)
-    P2PNetwork(
-        const P2PNetworkConfig& config,
-        std::shared_ptr<Test::MockLibp2pHost> host,
-        std::shared_ptr<Test::MockTransportManager> transport_manager,
-        std::shared_ptr<Test::MockSecurityManager> security_manager,
-        std::shared_ptr<Test::MockAutoNATService> autonat_service,
-        std::shared_ptr<Test::MockCircuitRelay> circuit_relay,
-        std::shared_ptr<Test::MockPerformanceMonitor> performance_monitor
-    );
-
-    // Regular constructor (for production use, not implemented yet)
     explicit P2PNetwork(const P2PNetworkConfig& config);
-
-    ~P2PNetwork() override = default;
+    ~P2PNetwork() override;
 
     // Network lifecycle
-    MultiplayerResult Start() override;
+    std::future<MultiplayerResult> Start() override;
     MultiplayerResult Stop() override;
     MultiplayerResult Shutdown() override;
     bool IsStarted() const override;
@@ -54,7 +33,7 @@ public:
     std::string GetPeerId() const override;
 
     // Connection management
-    MultiplayerResult ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) override;
+    std::future<MultiplayerResult> ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) override;
     MultiplayerResult DisconnectFromPeer(const std::string& peer_id) override;
     bool IsConnectedToPeer(const std::string& peer_id) const override;
     bool IsConnectedViaaRelay(const std::string& peer_id) const override;
@@ -68,7 +47,7 @@ public:
     void HandleIncomingMessage(const std::string& peer_id, const std::string& protocol, const std::vector<uint8_t>& data) override;
 
     // NAT traversal
-    MultiplayerResult DetectNATType() override;
+    std::future<MultiplayerResult> DetectNATType() override;
     bool CanTraverseNAT(NATType local_nat, NATType remote_nat) const override;
     std::vector<std::string> GetTraversalStrategies(NATType local_nat, NATType remote_nat) const override;
 
@@ -85,38 +64,8 @@ public:
     void SetOnRelayFailedCallback(std::function<void(const std::string&, const std::string&)> callback) override;
 
 private:
-    // Configuration
-    P2PNetworkConfig config_;
-
-    // Mock dependencies (for testing)
-    std::shared_ptr<Test::MockLibp2pHost> mock_host_;
-    std::shared_ptr<Test::MockTransportManager> mock_transport_manager_;
-    std::shared_ptr<Test::MockSecurityManager> mock_security_manager_;
-    std::shared_ptr<Test::MockAutoNATService> mock_autonat_service_;
-    std::shared_ptr<Test::MockCircuitRelay> mock_circuit_relay_;
-    std::shared_ptr<Test::MockPerformanceMonitor> mock_performance_monitor_;
-
-    // State tracking
-    mutable std::mutex state_mutex_;
-    std::unordered_set<std::string> connected_peers_;
-    std::unordered_set<std::string> relay_connected_peers_;
-    std::unordered_map<std::string, std::function<void(const std::string&, const std::vector<uint8_t>&)>> protocol_handlers_;
-
-    // Callbacks
-    std::function<void(const std::string&)> on_peer_connected_;
-    std::function<void(const std::string&)> on_peer_disconnected_;
-    std::function<void(const std::string&, const std::string&)> on_connection_failed_;
-    std::function<void(const std::string&, const std::string&, const std::vector<uint8_t>&)> on_message_received_;
-    std::function<void(NATType, bool)> on_nat_detected_;
-    std::function<void(const std::string&, const std::string&)> on_relay_connected_;
-    std::function<void(const std::string&, const std::string&)> on_relay_failed_;
-
-    // Helper methods
-    void ValidateConfiguration();
-    NATType ConvertMockNATType(int mock_type) const;
-    int ConvertToMockNATType(NATType nat_type) const;
-    MultiplayerResult AttemptDirectConnection(const std::string& peer_id, const std::string& multiaddr);
-    MultiplayerResult AttemptRelayConnection(const std::string& peer_id);
+    std::unique_ptr<Libp2pP2PNetwork> impl_;
+    mutable std::mutex callback_mutex_;
 };
 
 } // namespace Core::Multiplayer::ModelA

--- a/src/core/multiplayer/model_a/p2p_network_factory.cpp
+++ b/src/core/multiplayer/model_a/p2p_network_factory.cpp
@@ -3,7 +3,6 @@
 
 #include "p2p_network_factory.h"
 #include "p2p_network.h"
-#include "libp2p_p2p_network.h"
 
 namespace Core::Multiplayer::ModelA {
 
@@ -22,13 +21,13 @@ std::unique_ptr<IP2PNetwork> P2PNetworkFactory::Create(
 }
 
 std::unique_ptr<IP2PNetwork> P2PNetworkFactory::CreateMock(const P2PNetworkConfig& config) {
-    // Create mock implementation (existing P2PNetwork class with mock dependencies)
+    // Mock implementation uses the same facade with testing configuration
     return std::make_unique<P2PNetwork>(config);
 }
 
 std::unique_ptr<IP2PNetwork> P2PNetworkFactory::CreateLibp2p(const P2PNetworkConfig& config) {
-    // Create real libp2p implementation
-    return std::make_unique<Libp2pP2PNetwork>(config);
+    // Create facade which wraps real libp2p components
+    return std::make_unique<P2PNetwork>(config);
 }
 
 P2PNetworkFactory::Implementation P2PNetworkFactory::GetDefaultImplementation() {


### PR DESCRIPTION
## Summary
- Replace mock-based P2P network with facade over real libp2p implementation
- Expose Start, ConnectToPeer and NAT detection as asynchronous operations returning futures
- Guard callback registration with mutexes in both facade and libp2p implementation

## Testing
- `ctest -q`

------
https://chatgpt.com/codex/tasks/task_e_689510aeebfc832292d9b754b6f0521e