### PR TITLE
Improve TXT record parsing and validation

### DIFF
--- a/src/core/multiplayer/model_b/mdns_txt_records.h
+++ b/src/core/multiplayer/model_b/mdns_txt_records.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include <utility>
 
 #include "../common/error_codes.h"
 #include "mdns_discovery.h" // For GameSessionInfo
@@ -82,7 +83,7 @@ public:
     
     // Static factory methods
     static TxtRecordBuilder CreateGameSessionTxtRecords(const GameSessionInfo& session_info);
-    static TxtRecordBuilder FromMap(const std::unordered_map<std::string, std::string>& records);
+    static std::pair<ErrorCode, TxtRecordBuilder> FromMap(const std::unordered_map<std::string, std::string>& records);
 
 private:
     // This is a stub - implementation will be added during TDD green phase
@@ -141,7 +142,7 @@ public:
     
     // Static factory methods
     static TxtRecordParser ParseTxtRecords(const std::vector<uint8_t>& binary_data);
-    static TxtRecordParser FromMap(const std::unordered_map<std::string, std::string>& records);
+    static std::pair<ErrorCode, TxtRecordParser> FromMap(const std::unordered_map<std::string, std::string>& records);
 
 private:
     // This is a stub - implementation will be added during TDD green phase


### PR DESCRIPTION
## Summary
- Reserve storage when building TXT records and binary data
- Validate key/value pairs when converting maps to builders or parsers
- Detect duplicate keys and oversized data in parser

## Testing
- `g++ -std=c++17 -I./src -I./src/core/multiplayer -c src/core/multiplayer/model_b/mdns_txt_records.cpp`
- `./src/core/multiplayer/model_b/test_build/txt_test` *(fails: cannot execute binary file: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_689510b25d28832293237f2e3b1a73c4