### PR TITLE
Wire node updates and network queries to multiplayer backend

### DIFF
--- a/src/core/multiplayer/ldn_service_bridge.cpp
+++ b/src/core/multiplayer/ldn_service_bridge.cpp
@@ -9,6 +9,8 @@
 #include "sudachi/src/core/hle/service/ldn/ldn_results.h"
 #include "sudachi/src/core/hle/result.h"
 
+#include <mutex>
+
 namespace Service::LDN {
 
 /**
@@ -18,7 +20,7 @@ namespace Service::LDN {
 class ConcreteLdnServiceBridge : public LdnServiceBridge {
 public:
     using LdnServiceBridge::LdnServiceBridge;
-    
+
     Result Initialize() override {
         if (current_state_ != State::None) {
             return ResultBadState;
@@ -39,7 +41,12 @@ public:
         if (error != Core::Multiplayer::ErrorCode::Success) {
             return MapErrorToResult(error);
         }
-        
+
+        // Register callbacks for node join/leave events
+        current_backend_->RegisterNodeEventCallbacks(
+            [this](uint8_t node_id) { OnNodeJoined(node_id); },
+            [this](uint8_t node_id) { OnNodeLeft(node_id); });
+
         current_state_ = State::Initialized;
         return ResultSuccess;
     }
@@ -259,24 +266,40 @@ public:
         if (result != ResultSuccess) {
             return result;
         }
-        
-        // Clear and populate node updates (implementation will be enhanced)
-        out_updates.clear();
-        // TODO: Implement actual node update tracking
-        
+
+        // Retrieve and clear pending node updates atomically
+        {
+            std::lock_guard<std::mutex> lock(node_updates_mutex_);
+            out_updates = node_updates_;
+            node_updates_.clear();
+        }
+
         return ResultSuccess;
     }
-    
+
     Result GetIpv4Address(Ipv4Address& out_address, Ipv4Address& out_subnet) override {
-        // Return placeholder IP addresses - implementation will be enhanced
-        out_address = {192, 168, 1, 100};
-        out_subnet = {255, 255, 255, 0};
+        if (!current_backend_) {
+            return ResultInternalError;
+        }
+
+        auto error = current_backend_->GetIpv4Address(out_address, out_subnet);
+        if (error != Core::Multiplayer::ErrorCode::Success) {
+            return MapErrorToResult(error);
+        }
+
         return ResultSuccess;
     }
-    
+
     Result GetNetworkConfig(NetworkConfig& out_config) override {
-        // Return default config - implementation will be enhanced
-        out_config = {};
+        if (!current_backend_) {
+            return ResultInternalError;
+        }
+
+        auto error = current_backend_->GetNetworkConfig(out_config);
+        if (error != Core::Multiplayer::ErrorCode::Success) {
+            return MapErrorToResult(error);
+        }
+
         return ResultSuccess;
     }
     
@@ -397,6 +420,25 @@ private:
             return ResultInternalError;
         }
     }
+
+    void OnNodeJoined(uint8_t node_id) {
+        std::lock_guard<std::mutex> lock(node_updates_mutex_);
+        NodeLatestUpdate update{};
+        update.node_id = node_id;
+        update.is_connected = 1;
+        node_updates_.push_back(update);
+    }
+
+    void OnNodeLeft(uint8_t node_id) {
+        std::lock_guard<std::mutex> lock(node_updates_mutex_);
+        NodeLatestUpdate update{};
+        update.node_id = node_id;
+        update.is_connected = 0;
+        node_updates_.push_back(update);
+    }
+
+    std::mutex node_updates_mutex_;
+    std::vector<NodeLatestUpdate> node_updates_;
 };
 
 } // namespace Service::LDN

--- a/src/core/multiplayer/multiplayer_backend.h
+++ b/src/core/multiplayer/multiplayer_backend.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include <cstdint>
+#include <functional>
 
 #include "common/error_codes.h"
 
@@ -18,6 +19,8 @@ class ScanFilter;
 enum class State : uint32_t;
 class SecurityParameter;
 enum class DisconnectReason : uint32_t;
+class Ipv4Address;
+class NetworkConfig;
 }
 
 namespace Core::Multiplayer::HLE {
@@ -57,11 +60,20 @@ public:
     // Data transmission
     virtual ErrorCode SendPacket(const std::vector<uint8_t>& data, uint8_t node_id) = 0;
     virtual ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) = 0;
-    
+
     // Configuration and status
     virtual ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) = 0;
     virtual ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) = 0;
     virtual ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) = 0;
+
+    // Network details
+    virtual ErrorCode GetIpv4Address(Service::LDN::Ipv4Address& out_address,
+                                     Service::LDN::Ipv4Address& out_subnet) = 0;
+    virtual ErrorCode GetNetworkConfig(Service::LDN::NetworkConfig& out_config) = 0;
+
+    // Event callbacks
+    virtual void RegisterNodeEventCallbacks(std::function<void(uint8_t)> on_node_joined,
+                                            std::function<void(uint8_t)> on_node_left) = 0;
 };
 
 } // namespace Core::Multiplayer::HLE

--- a/tests/unit/hle_integration/test_multiplayer_backend_interface.cpp
+++ b/tests/unit/hle_integration/test_multiplayer_backend_interface.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include <optional>
+#include <functional>
 
 // Multiplayer system includes
 #include "src/core/multiplayer/common/error_codes.h"
@@ -65,6 +66,15 @@ public:
     virtual ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) = 0;
     virtual ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) = 0;
     virtual ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) = 0;
+
+    // Network details
+    virtual ErrorCode GetIpv4Address(Service::LDN::Ipv4Address& out_address,
+                                     Service::LDN::Ipv4Address& out_subnet) = 0;
+    virtual ErrorCode GetNetworkConfig(Service::LDN::NetworkConfig& out_config) = 0;
+
+    // Event callbacks
+    virtual void RegisterNodeEventCallbacks(std::function<void(uint8_t)> on_node_joined,
+                                            std::function<void(uint8_t)> on_node_left) = 0;
 };
 
 /**
@@ -103,6 +113,11 @@ public:
     MOCK_METHOD(ErrorCode, SetAdvertiseData, (const std::vector<uint8_t>&), (override));
     MOCK_METHOD(ErrorCode, GetSecurityParameter, (Service::LDN::SecurityParameter&), (override));
     MOCK_METHOD(ErrorCode, GetDisconnectReason, (Service::LDN::DisconnectReason&), (override));
+    MOCK_METHOD(ErrorCode, GetIpv4Address,
+                (Service::LDN::Ipv4Address&, Service::LDN::Ipv4Address&), (override));
+    MOCK_METHOD(ErrorCode, GetNetworkConfig, (Service::LDN::NetworkConfig&), (override));
+    MOCK_METHOD(void, RegisterNodeEventCallbacks,
+                (std::function<void(uint8_t)>, std::function<void(uint8_t)>), (override));
 };
 
 /**


### PR DESCRIPTION
## Summary
- Track node join and leave events through backend callbacks and return them from `GetNetworkInfoLatestUpdate`
- Query active backend for IPv4 address and configuration rather than using placeholders
- Extend backend interface with network query functions and node event callbacks

## Testing
- `ctest --test-dir build_ui_tests` *(fails: Unable to find executable: /Users/jbbrack03/Sudachi Multiplayer/build_ui_tests/ui_test_verification)*

------
https://chatgpt.com/codex/tasks/task_e_689510aced7c832298f6b7d4481b3858