### PR TITLE
Refactor P2PNetwork to use shared thread pool executor

### DIFF
--- a/src/core/multiplayer/model_a/p2p_network.cpp
+++ b/src/core/multiplayer/model_a/p2p_network.cpp
@@ -3,17 +3,91 @@
 
 #include "p2p_network.h"
 #include "libp2p_p2p_network.h"
+#include <condition_variable>
+#include <functional>
 #include <future>
+#include <queue>
+#include <thread>
+#include <type_traits>
+#include <utility>
 
 namespace Core::Multiplayer::ModelA {
 
+/**
+ * Simple thread pool executor used by P2PNetwork to run asynchronous tasks
+ * without spawning a new thread for each operation.
+ *
+ * Thread-safe: tasks can be submitted from multiple threads. The executor
+ * manages its worker threads and joins them on destruction, ensuring no tasks
+ * are left running when the owning P2PNetwork is destroyed.
+ */
+class AsyncExecutor {
+public:
+    explicit AsyncExecutor(size_t thread_count = std::thread::hardware_concurrency()) {
+        if (thread_count == 0) {
+            thread_count = 1;
+        }
+        for (size_t i = 0; i < thread_count; ++i) {
+            workers_.emplace_back([this] {
+                while (true) {
+                    std::function<void()> task;
+                    {
+                        std::unique_lock<std::mutex> lock(mutex_);
+                        cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+                        if (stop_ && tasks_.empty()) {
+                            return;
+                        }
+                        task = std::move(tasks_.front());
+                        tasks_.pop();
+                    }
+                    task();
+                }
+            });
+        }
+    }
+
+    ~AsyncExecutor() {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+        for (auto& worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+    }
+
+    template <typename Func>
+    auto Submit(Func&& f) -> std::future<typename std::invoke_result_t<Func>> {
+        using ReturnT = typename std::invoke_result_t<Func>;
+        auto task = std::make_shared<std::packaged_task<ReturnT()>>(std::forward<Func>(f));
+        auto fut = task->get_future();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            tasks_.emplace([task]() { (*task)(); });
+        }
+        cv_.notify_one();
+        return fut;
+    }
+
+private:
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool stop_ = false;
+};
+
 P2PNetwork::P2PNetwork(const P2PNetworkConfig& config)
-    : impl_(std::make_unique<Libp2pP2PNetwork>(config)) {}
+    : impl_(std::make_unique<Libp2pP2PNetwork>(config)),
+      executor_(std::make_shared<AsyncExecutor>()) {}
 
 P2PNetwork::~P2PNetwork() = default;
 
 std::future<MultiplayerResult> P2PNetwork::Start() {
-    return std::async(std::launch::async, [this] { return impl_->Start(); });
+    return executor_->Submit([this] { return impl_->Start(); });
 }
 
 MultiplayerResult P2PNetwork::Stop() { return impl_->Stop(); }
@@ -25,7 +99,7 @@ bool P2PNetwork::IsStarted() const { return impl_->IsStarted(); }
 std::string P2PNetwork::GetPeerId() const { return impl_->GetPeerId(); }
 
 std::future<MultiplayerResult> P2PNetwork::ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) {
-    return std::async(std::launch::async, [this, peer_id, multiaddr] {
+    return executor_->Submit([this, peer_id, multiaddr] {
         return impl_->ConnectToPeer(peer_id, multiaddr);
     });
 }
@@ -63,7 +137,7 @@ void P2PNetwork::HandleIncomingMessage(const std::string& peer_id, const std::st
 }
 
 std::future<MultiplayerResult> P2PNetwork::DetectNATType() {
-    return std::async(std::launch::async, [this] { return impl_->DetectNATType(); });
+    return executor_->Submit([this] { return impl_->DetectNATType(); });
 }
 
 bool P2PNetwork::CanTraverseNAT(NATType local_nat, NATType remote_nat) const {

--- a/src/core/multiplayer/model_a/p2p_network.h
+++ b/src/core/multiplayer/model_a/p2p_network.h
@@ -12,6 +12,7 @@
 namespace Core::Multiplayer::ModelA {
 
 class Libp2pP2PNetwork; // forward declaration
+class AsyncExecutor;    // forward declaration for shared executor
 
 /**
  * High level P2P network facade.
@@ -66,6 +67,17 @@ public:
 private:
     std::unique_ptr<Libp2pP2PNetwork> impl_;
     mutable std::mutex callback_mutex_;
+
+    /**
+     * @brief Shared executor providing a reusable worker thread pool.
+     *
+     * The executor is thread-safe and used by asynchronous APIs such as
+     * Start(), ConnectToPeer() and DetectNATType(). Tasks submitted to the
+     * executor run on a fixed pool of worker threads rather than spawning new
+     * threads on each request. The executor's lifetime is bound to the
+     * P2PNetwork instance and all worker threads are joined on destruction.
+     */
+    std::shared_ptr<AsyncExecutor> executor_;
 };
 
 } // namespace Core::Multiplayer::ModelA


### PR DESCRIPTION
## Summary
- Introduced `AsyncExecutor`, a simple reusable thread pool, to run P2P network operations without spawning a new thread for each call.
- Updated `P2PNetwork` async APIs (Start, ConnectToPeer, DetectNATType) to dispatch work through the shared executor and return futures from it.
- Documented executor thread-safety and lifecycle management in the public interface.

## Testing
- `cmake ../src/core/multiplayer/model_a -DBUILD_TESTING=OFF` *(fails: HunterGate configuration requires project and cmake_minimum_required)*
- `g++ -std=c++20 -I src -c src/core/multiplayer/model_a/p2p_network.cpp` *(fails: libp2p headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_689515c986908322818efc1fbe3a2a92