### PR TITLE
Use spdlog for multiplayer logging

### DIFF
--- a/src/core/multiplayer/common/circuit_breaker.cpp
+++ b/src/core/multiplayer/common/circuit_breaker.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <thread>
 #include <sstream>
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace Core::Multiplayer {
 
@@ -185,8 +185,9 @@ private:
         metrics_.consecutive_failures = 0;
         
         if (listener_) {
-            // For minimal implementation, just log success
-            std::cout << "Circuit breaker: Success recorded" << std::endl;
+            if (spdlog::should_log(spdlog::level::info)) {
+                spdlog::info("Circuit breaker: Success recorded");
+            }
         }
         
         // If in half-open state and we've had enough successes, close the circuit
@@ -202,8 +203,9 @@ private:
         metrics_.consecutive_failures = consecutive_failures_;
         
         if (listener_) {
-            // For minimal implementation, just log failure
-            std::cout << "Circuit breaker: Failure recorded, error " << static_cast<int>(error) << std::endl;
+            if (spdlog::should_log(spdlog::level::warn)) {
+                spdlog::warn("Circuit breaker: Failure recorded, error {}", static_cast<int>(error));
+            }
         }
         
         // Check if we should open the circuit
@@ -221,30 +223,36 @@ private:
         
         if (new_state == CircuitBreakerState::Open) {
             if (listener_) {
-                // For minimal implementation, just log
-                std::cout << "Circuit breaker: Circuit opened after " << consecutive_failures_ << " failures" << std::endl;
+                if (spdlog::should_log(spdlog::level::warn)) {
+                    spdlog::warn("Circuit breaker: Circuit opened after {} failures", consecutive_failures_);
+                }
             }
         } else if (new_state == CircuitBreakerState::Closed) {
             if (listener_) {
-                // For minimal implementation, just log
-                std::cout << "Circuit breaker: Circuit closed" << std::endl;
+                if (spdlog::should_log(spdlog::level::info)) {
+                    spdlog::info("Circuit breaker: Circuit closed");
+                }
             }
         } else if (new_state == CircuitBreakerState::HalfOpen) {
             half_open_calls_ = 0;
             if (listener_) {
-                // For minimal implementation, just log
-                std::cout << "Circuit breaker: Half-open test started" << std::endl;
+                if (spdlog::should_log(spdlog::level::info)) {
+                    spdlog::info("Circuit breaker: Half-open test started");
+                }
             }
         }
-        
+
         if (listener_) {
-            // For minimal implementation, just log state change
-            std::cout << "Circuit breaker: State changed from " << StateToString(old_state) 
-                      << " to " << StateToString(new_state) << std::endl;
+            if (spdlog::should_log(spdlog::level::info)) {
+                spdlog::info("Circuit breaker: State changed from {} to {}",
+                             StateToString(old_state), StateToString(new_state));
+            }
         }
-        
-        std::cout << "Circuit breaker state changed from " << StateToString(old_state) 
-                  << " to " << StateToString(new_state) << std::endl;
+
+        if (spdlog::should_log(spdlog::level::info)) {
+            spdlog::info("Circuit breaker state changed from {} to {}",
+                         StateToString(old_state), StateToString(new_state));
+        }
     }
 
     void TransitionToHalfOpen() {

--- a/src/core/multiplayer/common/connection_recovery_manager.cpp
+++ b/src/core/multiplayer/common/connection_recovery_manager.cpp
@@ -5,7 +5,7 @@
 #include <thread>
 #include <random>
 #include <algorithm>
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace Core::Multiplayer {
 
@@ -46,9 +46,10 @@ public:
         
         // Start recovery process in background thread
         recovery_thread_ = std::thread(&Impl::PerformRecovery, this);
-        
-        // Log recovery start (placeholder for actual logging)
-        std::cout << "Started recovery for error: " << static_cast<int>(error.error_code) << std::endl;
+
+        if (spdlog::should_log(spdlog::level::info)) {
+            spdlog::info("Started recovery for error: {}", static_cast<int>(error.error_code));
+        }
         return ErrorCode::Success;
     }
 
@@ -64,8 +65,10 @@ public:
         if (recovery_thread_.joinable()) {
             recovery_thread_.join();
         }
-        
-        std::cout << "Recovery stopped" << std::endl;
+
+        if (spdlog::should_log(spdlog::level::info)) {
+            spdlog::info("Recovery stopped");
+        }
         return ErrorCode::Success;
     }
 
@@ -241,8 +244,10 @@ private:
         // For minimal implementation, just log the attempt
         // In real implementation, this would call listener_->OnRecoveryAttempt()
         if (listener_ && current_error_.has_value()) {
-            std::cout << "Recovery attempt " << current_attempt_ << " for error " 
-                      << static_cast<int>(current_error_.value().error_code) << std::endl;
+            if (spdlog::should_log(spdlog::level::debug)) {
+                spdlog::debug("Recovery attempt {} for error {}", current_attempt_,
+                              static_cast<int>(current_error_.value().error_code));
+            }
         }
     }
 
@@ -250,8 +255,10 @@ private:
         // For minimal implementation, just log the success
         // In real implementation, this would call listener_->OnRecoverySucceeded()
         if (listener_ && current_error_.has_value()) {
-            std::cout << "Recovery succeeded for error " 
-                      << static_cast<int>(current_error_.value().error_code) << std::endl;
+            if (spdlog::should_log(spdlog::level::info)) {
+                spdlog::info("Recovery succeeded for error {}",
+                             static_cast<int>(current_error_.value().error_code));
+            }
         }
     }
 
@@ -259,9 +266,11 @@ private:
         // For minimal implementation, just log the failure
         // In real implementation, this would call listener_->OnRecoveryFailed()
         if (listener_ && current_error_.has_value()) {
-            std::cout << "Recovery failed for error " 
-                      << static_cast<int>(current_error_.value().error_code) 
-                      << " after " << current_attempt_ << " attempts" << std::endl;
+            if (spdlog::should_log(spdlog::level::err)) {
+                spdlog::error("Recovery failed for error {} after {} attempts",
+                              static_cast<int>(current_error_.value().error_code),
+                              current_attempt_);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace std::cout with spdlog in circuit breaker
- replace std::cout with spdlog in connection recovery manager

## Testing
- `g++ -std=c++17 -I src src/core/multiplayer/common/circuit_breaker.cpp -c -o /tmp/circuit_breaker.o`
- `g++ -std=c++17 -I src src/core/multiplayer/common/connection_recovery_manager.cpp -c -o /tmp/connection_recovery_manager.o`


------
https://chatgpt.com/codex/tasks/task_e_689515c7d6f88322a903f6066103a19f