### PR TITLE
Fix Relay Connectivity API name

### DIFF
--- a/src/core/multiplayer/model_a/i_p2p_network.h
+++ b/src/core/multiplayer/model_a/i_p2p_network.h
@@ -42,7 +42,11 @@ public:
     virtual std::future<MultiplayerResult> ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) = 0;
     virtual MultiplayerResult DisconnectFromPeer(const std::string& peer_id) = 0;
     virtual bool IsConnectedToPeer(const std::string& peer_id) const = 0;
-    virtual bool IsConnectedViaaRelay(const std::string& peer_id) const = 0;
+    virtual bool IsConnectedViaRelay(const std::string& peer_id) const = 0;
+    [[deprecated("Use IsConnectedViaRelay")]]
+    virtual bool IsConnectedViaaRelay(const std::string& peer_id) const {
+        return IsConnectedViaRelay(peer_id);
+    }
     virtual size_t GetConnectionCount() const = 0;
     virtual std::vector<std::string> GetConnectedPeers() const = 0;
 

--- a/src/core/multiplayer/model_a/libp2p_p2p_network.cpp
+++ b/src/core/multiplayer/model_a/libp2p_p2p_network.cpp
@@ -309,7 +309,7 @@ bool Libp2pP2PNetwork::IsConnectedToPeer(const std::string& peer_id) const {
     return connected_peers_.count(peer_id) > 0;
 }
 
-bool Libp2pP2PNetwork::IsConnectedViaaRelay(const std::string& peer_id) const {
+bool Libp2pP2PNetwork::IsConnectedViaRelay(const std::string& peer_id) const {
     std::lock_guard<std::mutex> lock(state_mutex_);
     return relay_connected_peers_.count(peer_id) > 0;
 }

--- a/src/core/multiplayer/model_a/libp2p_p2p_network.h
+++ b/src/core/multiplayer/model_a/libp2p_p2p_network.h
@@ -60,7 +60,11 @@ public:
     MultiplayerResult ConnectToPeer(const std::string& peer_id, const std::string& multiaddr);
     MultiplayerResult DisconnectFromPeer(const std::string& peer_id);
     bool IsConnectedToPeer(const std::string& peer_id) const;
-    bool IsConnectedViaaRelay(const std::string& peer_id) const;
+    bool IsConnectedViaRelay(const std::string& peer_id) const;
+    [[deprecated("Use IsConnectedViaRelay")]]
+    bool IsConnectedViaaRelay(const std::string& peer_id) const {
+        return IsConnectedViaRelay(peer_id);
+    }
     size_t GetConnectionCount() const;
     std::vector<std::string> GetConnectedPeers() const;
 

--- a/src/core/multiplayer/model_a/p2p_network.cpp
+++ b/src/core/multiplayer/model_a/p2p_network.cpp
@@ -38,8 +38,8 @@ bool P2PNetwork::IsConnectedToPeer(const std::string& peer_id) const {
     return impl_->IsConnectedToPeer(peer_id);
 }
 
-bool P2PNetwork::IsConnectedViaaRelay(const std::string& peer_id) const {
-    return impl_->IsConnectedViaaRelay(peer_id);
+bool P2PNetwork::IsConnectedViaRelay(const std::string& peer_id) const {
+    return impl_->IsConnectedViaRelay(peer_id);
 }
 
 size_t P2PNetwork::GetConnectionCount() const { return impl_->GetConnectionCount(); }

--- a/src/core/multiplayer/model_a/p2p_network.h
+++ b/src/core/multiplayer/model_a/p2p_network.h
@@ -36,7 +36,7 @@ public:
     std::future<MultiplayerResult> ConnectToPeer(const std::string& peer_id, const std::string& multiaddr) override;
     MultiplayerResult DisconnectFromPeer(const std::string& peer_id) override;
     bool IsConnectedToPeer(const std::string& peer_id) const override;
-    bool IsConnectedViaaRelay(const std::string& peer_id) const override;
+    bool IsConnectedViaRelay(const std::string& peer_id) const override;
     size_t GetConnectionCount() const override;
     std::vector<std::string> GetConnectedPeers() const override;
 

--- a/src/core/multiplayer/model_a/p2p_network_simple.cpp
+++ b/src/core/multiplayer/model_a/p2p_network_simple.cpp
@@ -48,7 +48,7 @@ std::string P2PNetwork::GetPeerId() const { throw std::runtime_error("Not implem
 MultiplayerResult P2PNetwork::ConnectToPeer(const std::string&, const std::string&) { throw std::runtime_error("Not implemented in production mode"); }
 MultiplayerResult P2PNetwork::DisconnectFromPeer(const std::string&) { throw std::runtime_error("Not implemented in production mode"); }
 bool P2PNetwork::IsConnectedToPeer(const std::string&) const { throw std::runtime_error("Not implemented in production mode"); }
-bool P2PNetwork::IsConnectedViaaRelay(const std::string&) const { throw std::runtime_error("Not implemented in production mode"); }
+bool P2PNetwork::IsConnectedViaRelay(const std::string&) const { throw std::runtime_error("Not implemented in production mode"); }
 size_t P2PNetwork::GetConnectionCount() const { throw std::runtime_error("Not implemented in production mode"); }
 std::vector<std::string> P2PNetwork::GetConnectedPeers() const { throw std::runtime_error("Not implemented in production mode"); }
 MultiplayerResult P2PNetwork::SendMessage(const std::string&, const std::string&, const std::vector<uint8_t>&) { throw std::runtime_error("Not implemented in production mode"); }

--- a/src/core/multiplayer/model_a/tests/test_p2p_network.cpp
+++ b/src/core/multiplayer/model_a/tests/test_p2p_network.cpp
@@ -502,7 +502,7 @@ TEST_F(P2PNetworkTest, FallsBackToRelayWhenDirectConnectionFails) {
 
     // ASSERT
     EXPECT_EQ(result, MultiplayerResult::Success);
-    EXPECT_TRUE(p2p_network->IsConnectedViaaRelay(TEST_PEER_ID));
+    EXPECT_TRUE(p2p_network->IsConnectedViaRelay(TEST_PEER_ID));
     EXPECT_TRUE(relay_connected);
 }
 


### PR DESCRIPTION
## Summary
- rename `IsConnectedViaaRelay` to `IsConnectedViaRelay`
- add deprecated `IsConnectedViaaRelay` shims for backward compatibility

## Testing
- `cmake ../tests -DBUILD_TESTING=ON` *(fails: Cannot find source file: unit/test_hle_interface.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_689515d29b248322ac7bf3961406743b