### PR TITLE
Fix attempt counter scope in recovery manager

### DIFF
--- a/src/core/multiplayer/common/connection_recovery_manager.cpp
+++ b/src/core/multiplayer/common/connection_recovery_manager.cpp
@@ -6,6 +6,7 @@
 #include <random>
 #include <algorithm>
 #include <iostream>
+#include <atomic>
 
 namespace Core::Multiplayer {
 
@@ -15,7 +16,7 @@ public:
     Impl(const RecoveryConfig& config, MockNetworkConnection* connection)
         : config_(config), connection_(connection), state_(RecoveryState::Idle),
           current_attempt_(0), listener_(nullptr),
-          rng_(std::random_device{}()) {
+          rng_(std::random_device{}()), attempt_count_(0) {
         
         start_time_ = std::chrono::steady_clock::now();
         
@@ -232,9 +233,8 @@ private:
         // For minimal implementation, simulate connection attempts
         // In real implementation, this would call connection_->Connect()
         // For now, simulate 50% success rate for recovery attempts
-        static int attempt_count = 0;
-        attempt_count++;
-        return (attempt_count % 2) == 0;
+        int attempt = ++attempt_count_;
+        return (attempt % 2) == 0;
     }
 
     void NotifyRecoveryAttempt() {
@@ -276,6 +276,7 @@ private:
     std::thread recovery_thread_;
     std::unordered_map<ErrorCode, MockRecoveryStrategy*> custom_strategies_;
     std::mt19937 rng_;
+    std::atomic<int> attempt_count_;
 };
 
 // ConnectionRecoveryManager implementation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(UNIT_TEST_SOURCES
     unit/test_relay_client.cpp
     unit/test_configuration.cpp
     unit/test_error_handling.cpp
+    unit/test_connection_recovery_manager.cpp
 )
 
 # Integration tests

--- a/tests/unit/test_connection_recovery_manager.cpp
+++ b/tests/unit/test_connection_recovery_manager.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 Sudachi Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <chrono>
+#include <gtest/gtest.h>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+
+#include "core/multiplayer/common/connection_recovery_manager.h"
+
+namespace Core::Multiplayer {
+// Minimal connection implementation for testing
+class MockNetworkConnection {};
+} // namespace Core::Multiplayer
+
+using namespace Core::Multiplayer;
+
+TEST(ConnectionRecoveryManagerTest, InstancesDoNotShareAttemptCount) {
+    RecoveryConfig config;
+    config.max_retries = 3;
+    config.initial_delay_ms = 1;
+    config.max_delay_ms = 1;
+    config.jitter_enabled = false;
+
+    MockNetworkConnection connection;
+
+    ConnectionRecoveryManager manager1(config, &connection);
+    ConnectionRecoveryManager manager2(config, &connection);
+
+    ErrorInfo error{ErrorCategory::NetworkConnectivity,
+                    ErrorCode::NetworkTimeout,
+                    "test",
+                    std::nullopt,
+                    {},
+                    std::chrono::steady_clock::now(),
+                    "test",
+                    {}};
+
+    ASSERT_EQ(ErrorCode::Success, manager1.StartRecovery(error));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_EQ(RecoveryState::Succeeded, manager1.GetState());
+
+    ASSERT_EQ(ErrorCode::Success, manager2.StartRecovery(error));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_EQ(RecoveryState::Succeeded, manager2.GetState());
+
+    manager1.Shutdown();
+    manager2.Shutdown();
+}
+


### PR DESCRIPTION
## Summary
- replace static attempt counter with per-instance `std::atomic<int>`
- add unit test verifying recovery instances don't share attempt state
- wire new test into CMake

## Testing
- `g++ -std=c++20 -I./src -I./tests -pthread tests/unit/test_connection_recovery_manager.cpp src/core/multiplayer/common/connection_recovery_manager.cpp -lgtest -lgtest_main -o connection_recovery_test && ./connection_recovery_test`


------
https://chatgpt.com/codex/tasks/task_e_689515ca54848322b65dbff9d2bf71f6