### PR TITLE
test: improve multiplayer backend assertions

### DIFF
--- a/tests/unit/core/test_multiplayer_integration.cpp
+++ b/tests/unit/core/test_multiplayer_integration.cpp
@@ -1,100 +1,99 @@
 // SPDX-FileCopyrightText: 2025 sudachi Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <gtest/gtest.h>
 #include "core/core.h"
+#include <gtest/gtest.h>
 
 #ifdef ENABLE_MULTIPLAYER
-#include "core/multiplayer/multiplayer_backend.h"
 #include "core/multiplayer/backend_factory.h"
+#include "core/multiplayer/multiplayer_backend.h"
 #endif
 
 namespace Core {
 
 class MultiplayerIntegrationTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        system = std::make_unique<System>();
+  void SetUp() override { system = std::make_unique<System>(); }
+
+  void TearDown() override {
+    if (system) {
+      system->Shutdown();
     }
-    
-    void TearDown() override {
-        if (system) {
-            system->Shutdown();
-        }
-        system.reset();
-    }
-    
-    std::unique_ptr<System> system;
+    system.reset();
+  }
+
+  std::unique_ptr<System> system;
 };
 
 #ifdef ENABLE_MULTIPLAYER
 
 TEST_F(MultiplayerIntegrationTest, SystemHasMultiplayerBackendGetter) {
-    // System should provide access to multiplayer backend
-    auto* backend = system->GetMultiplayerBackend();
-    
-    // Backend might be null if initialization failed, but getter should exist
-    // The important part is that the method exists and compiles
-    EXPECT_TRUE(backend == nullptr || backend != nullptr);
+  // System should provide access to multiplayer backend
+  auto *backend = system->GetMultiplayerBackend();
+
+  // Backend should be created when multiplayer support is enabled
+  ASSERT_NE(backend, nullptr);
+
+  // Newly created systems should have an initialized backend
+  EXPECT_TRUE(backend->IsInitialized());
 }
 
 TEST_F(MultiplayerIntegrationTest, SystemHasConstMultiplayerBackendGetter) {
-    const System* const_system = system.get();
-    
-    // Const version should also exist
-    const auto* backend = const_system->GetMultiplayerBackend();
-    
-    // Backend might be null if initialization failed, but getter should exist
-    EXPECT_TRUE(backend == nullptr || backend != nullptr);
+  const System *const_system = system.get();
+
+  // Const version should also exist
+  const auto *backend = const_system->GetMultiplayerBackend();
+
+  // Backend should exist and be initialized in const contexts as well
+  ASSERT_NE(backend, nullptr);
+  EXPECT_TRUE(backend->IsInitialized());
 }
 
-TEST_F(MultiplayerIntegrationTest, MultiplayerBackendInitializedDuringSystemInit) {
-    // Initialize a fresh system
-    System test_system;
-    
-    // After initialization, multiplayer backend should be available
-    // (might be null if initialization failed, but that's a runtime issue)
-    auto* backend = test_system.GetMultiplayerBackend();
-    
-    // If backend exists, it should be initialized
-    if (backend) {
-        // We can't test the actual state without knowing the backend interface
-        // but we can verify it's not a dangling pointer
-        EXPECT_NE(backend, nullptr);
-    }
+TEST_F(MultiplayerIntegrationTest,
+       MultiplayerBackendInitializedDuringSystemInit) {
+  // Initialize a fresh system
+  System test_system;
+
+  // After initialization, multiplayer backend should be available
+  auto *backend = test_system.GetMultiplayerBackend();
+
+  ASSERT_NE(backend, nullptr);
+  EXPECT_TRUE(backend->IsInitialized());
 }
 
 TEST_F(MultiplayerIntegrationTest, MultiplayerBackendCleanedUpDuringShutdown) {
-    // Create and initialize system
-    {
-        System test_system;
-        auto* backend_before = test_system.GetMultiplayerBackend();
-        
-        // Shutdown should clean up multiplayer backend
-        test_system.Shutdown();
-        
-        // After shutdown, backend should still be accessible but might be reset
-        auto* backend_after = test_system.GetMultiplayerBackend();
-        
-        // The pointer should be valid (not crash) even after shutdown
-        EXPECT_TRUE(backend_after == nullptr || backend_after != nullptr);
-    }
-    
-    // System destructor should not crash
-    EXPECT_TRUE(true);
+  // Create and initialize system
+  {
+    System test_system;
+    auto *backend_before = test_system.GetMultiplayerBackend();
+    ASSERT_NE(backend_before, nullptr);
+    EXPECT_TRUE(backend_before->IsInitialized());
+
+    // Shutdown should clean up multiplayer backend
+    test_system.Shutdown();
+
+    // After shutdown, backend should still be accessible but should no longer
+    // be initialized
+    auto *backend_after = test_system.GetMultiplayerBackend();
+    ASSERT_NE(backend_after, nullptr);
+    EXPECT_FALSE(backend_after->IsInitialized());
+  }
+
+  // System destructor should not crash
+  EXPECT_TRUE(true);
 }
 
 #else // !ENABLE_MULTIPLAYER
 
 TEST_F(MultiplayerIntegrationTest, MultiplayerDisabledBuild) {
-    // When ENABLE_MULTIPLAYER is not defined, the system should still work
-    EXPECT_NE(system.get(), nullptr);
-    
-    // System should initialize without multiplayer
-    system->Initialize();
-    
-    // And shutdown cleanly
-    system->Shutdown();
+  // When ENABLE_MULTIPLAYER is not defined, the system should still work
+  EXPECT_NE(system.get(), nullptr);
+
+  // System should initialize without multiplayer
+  system->Initialize();
+
+  // And shutdown cleanly
+  system->Shutdown();
 }
 
 #endif // ENABLE_MULTIPLAYER


### PR DESCRIPTION
## Summary
- replace tautological backend pointer checks with explicit assertions
- verify multiplayer backend is initialized on system creation
- ensure backend cleanup resets initialization state

## Testing
- `mkdir build && cd build && cmake .. && cmake --build . && ctest --output-on-failure` *(fails: The source directory "/workspace/Denton" does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68951c21fcd88322aefb3d7690162678