### PR TITLE
refactor: remove redundant expect

### DIFF
--- a/src/core/multiplayer/model_a/tests/test_compilation_check.cpp
+++ b/src/core/multiplayer/model_a/tests/test_compilation_check.cpp
@@ -15,8 +15,8 @@
 
 // This test verifies that all our implementations compile correctly
 TEST(CompilationCheck, AllHeadersCompile) {
-    // If this test compiles and runs, it means our headers are valid
-    EXPECT_TRUE(true);
+    // If this test compiles the headers are valid; no runtime behavior
+    GTEST_SKIP() << "Compilation check only";
 }
 
 // Verify basic type instantiation

--- a/src/core/multiplayer/model_b/platform/windows/test_windows_capability_detector.cpp
+++ b/src/core/multiplayer/model_b/platform/windows/test_windows_capability_detector.cpp
@@ -246,7 +246,11 @@ TEST_F(WindowsCapabilityDetectorTest, GetDiagnosticReport_ReturnsNonEmptyReport)
 #else // Not Windows
 
 TEST(WindowsCapabilityDetectorTest, NotAvailableOnNonWindows) {
-    EXPECT_TRUE(true); // Dummy test for non-Windows platforms
+#ifdef _WIN32
+    FAIL() << "Test should not run on Windows";
+#else
+    GTEST_SKIP() << "Windows capability detection unavailable on this platform";
+#endif
 }
 
 #endif // _WIN32

--- a/src/core/multiplayer/model_b/tests/verify_red_phase.cpp
+++ b/src/core/multiplayer/model_b/tests/verify_red_phase.cpp
@@ -41,7 +41,6 @@ TEST(TddRedPhaseVerification, HeaderFilesExistAndCompile) {
     // This test passes if we reach here without compilation errors
     EXPECT_EQ(static_cast<int>(state), 0);
     EXPECT_EQ(static_cast<int>(version), 0);
-    EXPECT_TRUE(true); // Compilation success indicator
 }
 
 /**
@@ -67,8 +66,8 @@ TEST(TddRedPhaseVerification, ImplementationClassesAreStubs) {
     
     // Check that mock types are defined
     static_assert(std::is_class_v<MockMdnsSocket>, "MockMdnsSocket should be a class");
-    
-    EXPECT_TRUE(true); // Interface verification success
+
+    GTEST_SKIP() << "Interface verification compile check";
 }
 
 /**
@@ -88,8 +87,6 @@ TEST(TddRedPhaseVerification, PrintTestSummary) {
     std::cout << "\nNext Phase: Implement MdnsDiscovery and TxtRecord classes" << std::endl;
     std::cout << "to make tests pass (GREEN PHASE)" << std::endl;
     std::cout << "===================================\n" << std::endl;
-    
-    EXPECT_TRUE(true); // Always pass for informational test
 }
 
 int main(int argc, char** argv) {

--- a/src/core/multiplayer/model_b/tests/verify_windows_red_phase.cpp
+++ b/src/core/multiplayer/model_b/tests/verify_windows_red_phase.cpp
@@ -3,6 +3,9 @@
 
 #include <gtest/gtest.h>
 #include <iostream>
+#include "../platform/windows/mobile_hotspot_manager.h"
+#include "../platform/windows/mobile_hotspot_capabilities.h"
+#include "../../common/error_codes.h"
 
 /**
  * TDD Red Phase Verification for Windows Mobile Hotspot Manager
@@ -28,9 +31,9 @@ TEST(WindowsRedPhaseVerification, MobileHotspotManagerTestsExist) {
     std::cout << "6. MobileHotspotManagerErrorTest (5 tests)\n";
     std::cout << "7. MobileHotspotManagerThreadSafetyTest (3 tests)\n";
     std::cout << "Total: 32+ failing tests for Mobile Hotspot Manager\n";
-    
-    // This should pass - it's just documenting our test structure
-    EXPECT_TRUE(true);
+
+    using namespace Core::Multiplayer::ModelB::Windows;
+    EXPECT_EQ(static_cast<int>(HotspotState::Uninitialized), 0);
 }
 
 TEST(WindowsRedPhaseVerification, MobileHotspotCapabilitiesTestsExist) {
@@ -42,9 +45,10 @@ TEST(WindowsRedPhaseVerification, MobileHotspotCapabilitiesTestsExist) {
     std::cout << "5. MobileHotspotCapabilitiesFallbackTest (3 tests)\n";
     std::cout << "6. MobileHotspotCapabilitiesTest (2 tests)\n";
     std::cout << "Total: 22+ failing tests for Mobile Hotspot Capabilities\n";
-    
-    // This should pass - it's just documenting our test structure
-    EXPECT_TRUE(true);
+
+    using namespace Core::Multiplayer::ModelB::Windows;
+    MobileHotspotCapabilities caps;
+    EXPECT_TRUE(caps.IsHotspotSupportedByVersion());
 }
 
 TEST(WindowsRedPhaseVerification, TestingSummary) {
@@ -81,9 +85,10 @@ TEST(WindowsRedPhaseVerification, TestingSummary) {
     std::cout << "5. Make tests pass one by one\n";
     
     std::cout << "\n================================================\n";
-    
-    // This test passes to confirm our setup is complete
-    EXPECT_TRUE(true);
+
+    using namespace Core::Multiplayer::ModelB::Windows;
+    MobileHotspotManager manager;
+    EXPECT_EQ(manager.StartHotspot(), Core::Multiplayer::ErrorCode::NotInitialized);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Summary
- mark AllHeadersCompile as a pure compilation check
- drop placeholder expectations in red-phase verification tests
- verify Windows-specific symbols and error paths instead of unconditional passes

## Testing
- `g++ -std=c++17 src/core/multiplayer/model_b/tests/verify_windows_red_phase.cpp src/core/multiplayer/model_b/platform/windows/mobile_hotspot_capabilities.cpp src/core/multiplayer/model_b/platform/windows/mobile_hotspot_manager.cpp -I src -I build_compilation/_deps/googletest-src/googletest/include -L build_compilation/lib -lgtest_main -lgtest -pthread -o build_compilation/verify_windows_red_phase_test && build_compilation/verify_windows_red_phase_test >/tmp/verify_win.log && tail -n 20 /tmp/verify_win.log`
- `g++ -std=c++17 src/core/multiplayer/model_b/platform/windows/test_windows_capability_detector.cpp -I src -I build_compilation/_deps/googletest-src/googletest/include -L build_compilation/lib -lgtest_main -lgtest -pthread -o build_compilation/test_windows_capability_detector && build_compilation/test_windows_capability_detector >/tmp/win_cap.log && tail -n 20 /tmp/win_cap.log`


------
https://chatgpt.com/codex/tasks/task_e_68951c2307ac832294526e79861d5b0e