### PR TITLE
Refactor network types and error handling

### DIFF
--- a/src/core/multiplayer/error_code_mapper.h
+++ b/src/core/multiplayer/error_code_mapper.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <chrono>
+#include <memory>
 
 #include "common/error_codes.h"
 
@@ -39,5 +40,8 @@ public:
     // Get suggested retry delay for recoverable errors
     virtual std::chrono::milliseconds GetRetryDelay(ErrorCode error) = 0;
 };
+
+// Factory function to create a concrete mapper instance
+std::unique_ptr<ErrorCodeMapper> CreateErrorCodeMapper();
 
 } // namespace Core::Multiplayer::HLE

--- a/src/core/multiplayer/model_a/model_a_backend.cpp
+++ b/src/core/multiplayer/model_a/model_a_backend.cpp
@@ -82,6 +82,14 @@ ErrorCode ModelABackend::SetAdvertiseData(const std::vector<uint8_t>&) {
     return ErrorCode::NotImplemented;
 }
 
+ErrorCode ModelABackend::SetStationAcceptPolicy(Service::LDN::AcceptPolicy) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelABackend::AddAcceptFilterEntry(const Service::LDN::MacAddress&) {
+    return ErrorCode::NotImplemented;
+}
+
 ErrorCode ModelABackend::GetSecurityParameter(Service::LDN::SecurityParameter&) {
     return ErrorCode::NotImplemented;
 }

--- a/src/core/multiplayer/model_a/model_a_backend.h
+++ b/src/core/multiplayer/model_a/model_a_backend.h
@@ -40,6 +40,8 @@ public:
     ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) override;
 
     ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) override;
+    ErrorCode SetStationAcceptPolicy(Service::LDN::AcceptPolicy policy) override;
+    ErrorCode AddAcceptFilterEntry(const Service::LDN::MacAddress& mac) override;
     ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) override;
     ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) override;
 

--- a/src/core/multiplayer/model_b/model_b_backend.cpp
+++ b/src/core/multiplayer/model_b/model_b_backend.cpp
@@ -82,6 +82,14 @@ ErrorCode ModelBBackend::SetAdvertiseData(const std::vector<uint8_t>&) {
     return ErrorCode::NotImplemented;
 }
 
+ErrorCode ModelBBackend::SetStationAcceptPolicy(Service::LDN::AcceptPolicy) {
+    return ErrorCode::NotImplemented;
+}
+
+ErrorCode ModelBBackend::AddAcceptFilterEntry(const Service::LDN::MacAddress&) {
+    return ErrorCode::NotImplemented;
+}
+
 ErrorCode ModelBBackend::GetSecurityParameter(Service::LDN::SecurityParameter&) {
     return ErrorCode::NotImplemented;
 }

--- a/src/core/multiplayer/model_b/model_b_backend.h
+++ b/src/core/multiplayer/model_b/model_b_backend.h
@@ -40,6 +40,8 @@ public:
     ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) override;
 
     ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) override;
+    ErrorCode SetStationAcceptPolicy(Service::LDN::AcceptPolicy policy) override;
+    ErrorCode AddAcceptFilterEntry(const Service::LDN::MacAddress& mac) override;
     ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) override;
     ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) override;
 

--- a/src/core/multiplayer/multiplayer_backend.h
+++ b/src/core/multiplayer/multiplayer_backend.h
@@ -21,6 +21,8 @@ class SecurityParameter;
 enum class DisconnectReason : uint32_t;
 class Ipv4Address;
 class NetworkConfig;
+enum class AcceptPolicy : uint8_t;
+class MacAddress;
 }
 
 namespace Core::Multiplayer::HLE {
@@ -63,6 +65,8 @@ public:
 
     // Configuration and status
     virtual ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) = 0;
+    virtual ErrorCode SetStationAcceptPolicy(Service::LDN::AcceptPolicy policy) = 0;
+    virtual ErrorCode AddAcceptFilterEntry(const Service::LDN::MacAddress& mac) = 0;
     virtual ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) = 0;
     virtual ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) = 0;
 

--- a/src/core/multiplayer/type_translator.cpp
+++ b/src/core/multiplayer/type_translator.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <random>
 
 #include "sudachi/src/core/hle/service/ldn/ldn_types.h"
 
@@ -91,14 +92,10 @@ public:
     std::memcpy(ldn.user_name.data(), internal.user_name.data(), name_size);
 
     // Convert MAC address
-    if (internal.mac_address.size() >= 6) {
-      std::memcpy(ldn.mac_address.raw.data(), internal.mac_address.data(), 6);
-    }
+    std::memcpy(ldn.mac_address.raw.data(), internal.mac_address.data(), 6);
 
     // Convert IPv4 address
-    if (internal.ipv4_address.size() >= 4) {
-      std::memcpy(ldn.ipv4_address.data(), internal.ipv4_address.data(), 4);
-    }
+    std::memcpy(ldn.ipv4_address.data(), internal.ipv4_address.data(), 4);
 
     return ldn;
   }
@@ -119,11 +116,9 @@ public:
     internal.user_name.assign(name_data, name_end);
 
     // Convert MAC address
-    internal.mac_address.resize(6);
     std::memcpy(internal.mac_address.data(), ldn.mac_address.raw.data(), 6);
 
     // Convert IPv4 address
-    internal.ipv4_address.resize(4);
     std::memcpy(internal.ipv4_address.data(), ldn.ipv4_address.data(), 4);
 
     return internal;
@@ -210,37 +205,29 @@ public:
   }
 
   Service::LDN::MacAddress
-  ToLdnMacAddress(const std::vector<uint8_t> &internal_mac) override {
+  ToLdnMacAddress(const std::array<uint8_t, 6> &internal_mac) override {
     Service::LDN::MacAddress ldn_mac{};
-
-    if (internal_mac.size() >= 6) {
-      std::memcpy(ldn_mac.raw.data(), internal_mac.data(), 6);
-    }
-
+    std::memcpy(ldn_mac.raw.data(), internal_mac.data(), 6);
     return ldn_mac;
   }
 
-  std::vector<uint8_t>
+  std::array<uint8_t, 6>
   FromLdnMacAddress(const Service::LDN::MacAddress &ldn_mac) override {
-    std::vector<uint8_t> internal_mac(6);
+    std::array<uint8_t, 6> internal_mac{};
     std::memcpy(internal_mac.data(), ldn_mac.raw.data(), 6);
     return internal_mac;
   }
 
   Service::LDN::Ipv4Address
-  ToLdnIpv4Address(const std::vector<uint8_t> &internal_ip) override {
+  ToLdnIpv4Address(const std::array<uint8_t, 4> &internal_ip) override {
     Service::LDN::Ipv4Address ldn_ip{};
-
-    if (internal_ip.size() >= 4) {
-      std::memcpy(ldn_ip.data(), internal_ip.data(), 4);
-    }
-
+    std::memcpy(ldn_ip.data(), internal_ip.data(), 4);
     return ldn_ip;
   }
 
-  std::vector<uint8_t>
+  std::array<uint8_t, 4>
   FromLdnIpv4Address(const Service::LDN::Ipv4Address &ldn_ip) override {
-    std::vector<uint8_t> internal_ip(4);
+    std::array<uint8_t, 4> internal_ip{};
     std::memcpy(internal_ip.data(), ldn_ip.data(), 4);
     return internal_ip;
   }
@@ -287,10 +274,11 @@ public:
           ldn.security_config.passphrase_size);
     }
 
-    // Generate session ID (placeholder - should be generated properly)
+    // Generate cryptographically secure random session ID
     internal.session_id.resize(16);
-    for (size_t i = 0; i < 16; ++i) {
-      internal.session_id[i] = static_cast<uint8_t>(i); // Placeholder
+    std::random_device rd;
+    for (auto &byte : internal.session_id) {
+      byte = static_cast<uint8_t>(rd());
     }
 
     return internal;

--- a/src/core/multiplayer/type_translator.h
+++ b/src/core/multiplayer/type_translator.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <cstdint>
+#include <array>
 
 // Forward declarations for LDN types
 namespace Service::LDN {
@@ -42,8 +43,8 @@ struct InternalNetworkInfo {
 struct InternalNodeInfo {
     uint8_t node_id;
     std::string user_name;
-    std::vector<uint8_t> mac_address;
-    std::vector<uint8_t> ipv4_address;
+    std::array<uint8_t, 6> mac_address{};
+    std::array<uint8_t, 4> ipv4_address{};
     bool is_connected;
     uint16_t local_communication_version;
 };
@@ -89,11 +90,11 @@ public:
         const std::vector<Service::LDN::NetworkInfo>& ldn_results) = 0;
     
     // Address translations
-    virtual Service::LDN::MacAddress ToLdnMacAddress(const std::vector<uint8_t>& internal_mac) = 0;
-    virtual std::vector<uint8_t> FromLdnMacAddress(const Service::LDN::MacAddress& ldn_mac) = 0;
-    
-    virtual Service::LDN::Ipv4Address ToLdnIpv4Address(const std::vector<uint8_t>& internal_ip) = 0;
-    virtual std::vector<uint8_t> FromLdnIpv4Address(const Service::LDN::Ipv4Address& ldn_ip) = 0;
+    virtual Service::LDN::MacAddress ToLdnMacAddress(const std::array<uint8_t, 6>& internal_mac) = 0;
+    virtual std::array<uint8_t, 6> FromLdnMacAddress(const Service::LDN::MacAddress& ldn_mac) = 0;
+
+    virtual Service::LDN::Ipv4Address ToLdnIpv4Address(const std::array<uint8_t, 4>& internal_ip) = 0;
+    virtual std::array<uint8_t, 4> FromLdnIpv4Address(const Service::LDN::Ipv4Address& ldn_ip) = 0;
     
     // Configuration translations
     virtual Service::LDN::CreateNetworkConfig ToLdnCreateConfig(const InternalSessionInfo& internal) = 0;

--- a/tests/unit/hle_integration/test_helpers.h
+++ b/tests/unit/hle_integration/test_helpers.h
@@ -39,6 +39,8 @@ public:
     virtual ErrorCode ReceivePacket(std::vector<uint8_t>& out_data, uint8_t& out_node_id) = 0;
 
     virtual ErrorCode SetAdvertiseData(const std::vector<uint8_t>& data) = 0;
+    virtual ErrorCode SetStationAcceptPolicy(Service::LDN::AcceptPolicy policy) = 0;
+    virtual ErrorCode AddAcceptFilterEntry(const Service::LDN::MacAddress& mac) = 0;
     virtual ErrorCode GetSecurityParameter(Service::LDN::SecurityParameter& out_param) = 0;
     virtual ErrorCode GetDisconnectReason(Service::LDN::DisconnectReason& out_reason) = 0;
     virtual ErrorCode GetIpv4Address(Service::LDN::Ipv4Address& out_address,
@@ -70,6 +72,8 @@ public:
     MOCK_METHOD(ErrorCode, SendPacket, (const std::vector<uint8_t>&, uint8_t), (override));
     MOCK_METHOD(ErrorCode, ReceivePacket, (std::vector<uint8_t>&, uint8_t&), (override));
     MOCK_METHOD(ErrorCode, SetAdvertiseData, (const std::vector<uint8_t>&), (override));
+    MOCK_METHOD(ErrorCode, SetStationAcceptPolicy, (Service::LDN::AcceptPolicy), (override));
+    MOCK_METHOD(ErrorCode, AddAcceptFilterEntry, (const Service::LDN::MacAddress&), (override));
     MOCK_METHOD(ErrorCode, GetSecurityParameter, (Service::LDN::SecurityParameter&), (override));
     MOCK_METHOD(ErrorCode, GetDisconnectReason, (Service::LDN::DisconnectReason&), (override));
     MOCK_METHOD(ErrorCode, GetIpv4Address,
@@ -194,6 +198,14 @@ public:
         if (data.size() > Service::LDN::AdvertiseDataSizeMax)
             return ErrorCode::MessageTooLarge;
         advertise_data_ = data;
+        return ErrorCode::Success;
+    }
+
+    ErrorCode SetStationAcceptPolicy(Service::LDN::AcceptPolicy) override {
+        return ErrorCode::Success;
+    }
+
+    ErrorCode AddAcceptFilterEntry(const Service::LDN::MacAddress&) override {
         return ErrorCode::Success;
     }
 


### PR DESCRIPTION
## Summary
- Replace dynamic MAC/IP containers with fixed arrays and update translators
- Generate cryptographically secure session IDs
- Switch error code mapping to unordered maps and centralize LDN error translation
- Forward station acceptance policy and filter calls to backends

## Testing
- `ctest` *(failed: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6895241a90e08322b769e8a2508b2460