### PR TITLE
Refactor WiFi Direct wrapper threading for clean shutdown

### DIFF
--- a/src/core/multiplayer/model_b/tests/test_wifi_direct_wrapper.cpp
+++ b/src/core/multiplayer/model_b/tests/test_wifi_direct_wrapper.cpp
@@ -58,6 +58,7 @@ TEST_F(WiFiDirectWrapperTest, StartAndStopDiscovery) {
     wrapper->Initialize(mock_env.get(), mock_context.get());
     EXPECT_EQ(wrapper->StartDiscovery(nullptr), ErrorCode::Success);
     EXPECT_EQ(wrapper->GetState(), WifiDirectState::Discovering);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     EXPECT_EQ(wrapper->StopDiscovery(), ErrorCode::Success);
     EXPECT_EQ(wrapper->GetState(), WifiDirectState::Initialized);
 }
@@ -76,6 +77,16 @@ TEST_F(WiFiDirectWrapperTest, ConnectAndDisconnectPeer) {
     std::this_thread::sleep_for(std::chrono::milliseconds(150));
     EXPECT_EQ(wrapper->GetState(), WifiDirectState::Connected);
     EXPECT_EQ(wrapper->DisconnectFromPeer(), ErrorCode::Success);
+    EXPECT_EQ(wrapper->GetState(), WifiDirectState::Initialized);
+}
+
+TEST_F(WiFiDirectWrapperTest, CancelConnectionBeforeCompletion) {
+    CreateWrapper();
+    wrapper->Initialize(mock_env.get(), mock_context.get());
+    EXPECT_EQ(wrapper->ConnectToPeer("11:22:33:44:55:66"), ErrorCode::Success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_EQ(wrapper->CancelConnection(), ErrorCode::Success);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     EXPECT_EQ(wrapper->GetState(), WifiDirectState::Initialized);
 }
 


### PR DESCRIPTION
## Summary
- Replace detached threads in WiFiDirectWrapper with joinable worker threads and cancellation flags
- Ensure Shutdown, StartDiscovery, and ConnectToPeer cleanly cancel and join threads
- Extend WiFi Direct wrapper tests for thread cancellation and asynchronous behavior

## Testing
- `g++ -std=c++17 src/core/multiplayer/model_b/platform/android/wifi_direct_wrapper.cpp src/core/multiplayer/model_b/tests/test_wifi_direct_wrapper.cpp -I/usr/lib/jvm/java-17-openjdk-amd64/include -I/usr/lib/jvm/java-17-openjdk-amd64/include/linux -I src/core/multiplayer/model_b/tests -I src/core/multiplayer/model_b -I src/core/multiplayer -I src/core -I src -pthread -lgtest -lgmock -o wifi_test` *(fails: request for member 'get' in non-class type ‘int’)*

------
https://chatgpt.com/codex/tasks/task_e_68960a0cac78832290f122a70f8791de