### PR TITLE
Cache Windows network adapter enumeration for capability checks

### DIFF
--- a/src/core/multiplayer/model_b/platform/windows/windows_capability_detector.cpp
+++ b/src/core/multiplayer/model_b/platform/windows/windows_capability_detector.cpp
@@ -5,20 +5,21 @@
 
 #ifdef _WIN32
 
-#include <windows.h>
-#include <versionhelpers.h>
-#include <shlobj.h>
-#include <winsock2.h>
 #include <iphlpapi.h>
+#include <mutex>
+#include <shlobj.h>
 #include <sstream>
 #include <vector>
+#include <versionhelpers.h>
+#include <windows.h>
+#include <winsock2.h>
 
 // WinRT headers - conditionally included based on SDK availability
 #if defined(WINRT_BASE_H)
-#include <winrt/base.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Networking.Connectivity.h>
 #include <winrt/Windows.Networking.NetworkOperators.h>
+#include <winrt/base.h>
 #endif
 
 #pragma comment(lib, "iphlpapi.lib")
@@ -26,435 +27,499 @@
 
 namespace Core::Multiplayer::ModelB::Windows {
 
-WindowsCapabilityDetector::WindowsVersionInfo WindowsCapabilityDetector::GetWindowsVersion() {
-    WindowsVersionInfo info{};
-    
-    // Use RtlGetVersion for accurate version info (GetVersionEx is deprecated)
-    typedef NTSTATUS (WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if (ntdll) {
-        RtlGetVersionPtr rtlGetVersion = (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
-        if (rtlGetVersion) {
-            RTL_OSVERSIONINFOW versionInfo = {};
-            versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
-            if (rtlGetVersion(&versionInfo) == 0) { // STATUS_SUCCESS
-                info.major_version = versionInfo.dwMajorVersion;
-                info.minor_version = versionInfo.dwMinorVersion;
-                info.build_number = versionInfo.dwBuildNumber;
-                
-                // Format version string
-                std::stringstream ss;
-                ss << info.major_version << "." << info.minor_version << "." << info.build_number;
-                info.version_string = ss.str();
-                
-                // Determine Windows edition
-                if (info.major_version == 10) {
-                    if (info.build_number >= 22000) {
-                        info.edition = "Windows 11";
-                    } else {
-                        info.edition = "Windows 10";
-                    }
-                } else if (info.major_version == 6 && info.minor_version == 3) {
-                    info.edition = "Windows 8.1";
-                } else if (info.major_version == 6 && info.minor_version == 2) {
-                    info.edition = "Windows 8";
-                } else {
-                    info.edition = "Unknown";
-                }
-            }
-        }
+namespace {
+
+struct AdapterCache {
+  std::vector<BYTE> buffer;
+  PIP_ADAPTER_ADDRESSES addresses{nullptr};
+  bool initialized{false};
+  std::mutex mutex;
+};
+
+AdapterCache g_adapter_cache;
+
+PIP_ADAPTER_ADDRESSES GetCachedAdapters() {
+  std::lock_guard<std::mutex> lock(g_adapter_cache.mutex);
+  if (!g_adapter_cache.initialized) {
+    ULONG bufferSize = 0;
+    GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr,
+                         &bufferSize);
+    g_adapter_cache.buffer.resize(bufferSize);
+    g_adapter_cache.addresses =
+        reinterpret_cast<PIP_ADAPTER_ADDRESSES>(g_adapter_cache.buffer.data());
+    if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
+                             g_adapter_cache.addresses,
+                             &bufferSize) != NO_ERROR) {
+      g_adapter_cache.addresses = nullptr;
+      g_adapter_cache.buffer.clear();
     }
-    
-    return info;
+    g_adapter_cache.initialized = true;
+  }
+  return g_adapter_cache.addresses;
+}
+
+} // namespace
+
+WindowsCapabilityDetector::WindowsVersionInfo
+WindowsCapabilityDetector::GetWindowsVersion() {
+  WindowsVersionInfo info{};
+
+  // Use RtlGetVersion for accurate version info (GetVersionEx is deprecated)
+  typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+  if (ntdll) {
+    RtlGetVersionPtr rtlGetVersion =
+        (RtlGetVersionPtr)GetProcAddress(ntdll, "RtlGetVersion");
+    if (rtlGetVersion) {
+      RTL_OSVERSIONINFOW versionInfo = {};
+      versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
+      if (rtlGetVersion(&versionInfo) == 0) { // STATUS_SUCCESS
+        info.major_version = versionInfo.dwMajorVersion;
+        info.minor_version = versionInfo.dwMinorVersion;
+        info.build_number = versionInfo.dwBuildNumber;
+
+        // Format version string
+        std::stringstream ss;
+        ss << info.major_version << "." << info.minor_version << "."
+           << info.build_number;
+        info.version_string = ss.str();
+
+        // Determine Windows edition
+        if (info.major_version == 10) {
+          if (info.build_number >= 22000) {
+            info.edition = "Windows 11";
+          } else {
+            info.edition = "Windows 10";
+          }
+        } else if (info.major_version == 6 && info.minor_version == 3) {
+          info.edition = "Windows 8.1";
+        } else if (info.major_version == 6 && info.minor_version == 2) {
+          info.edition = "Windows 8";
+        } else {
+          info.edition = "Unknown";
+        }
+      }
+    }
+  }
+
+  return info;
 }
 
 bool WindowsCapabilityDetector::IsWindows10OrLater() {
-    return IsWindows10OrGreater();
+  return IsWindows10OrGreater();
 }
 
 bool WindowsCapabilityDetector::IsWindows10Version1607OrLater() {
-    auto version = GetWindowsVersion();
-    return version.major_version >= 10 && version.build_number >= 14393;
+  auto version = GetWindowsVersion();
+  return version.major_version >= 10 && version.build_number >= 14393;
 }
 
-WindowsCapabilityDetector::WinRTCapabilities WindowsCapabilityDetector::DetectWinRTCapabilities() {
-    WinRTCapabilities caps{};
-    
-    // Check if WinRT can be initialized
-    caps.winrt_available = CanInitializeWinRT();
-    
-    // Check Windows version for API availability
-    if (IsWindows10Version1607OrLater()) {
-        caps.mobile_hotspot_api_available = true;
-    }
-    
-    // WiFi Direct is available on Windows 8+
-    if (IsWindows8OrGreater()) {
-        caps.wifi_direct_available = true;
-    }
-    
-    // Check for loopback adapter
-    caps.loopback_adapter_installed = IsLoopbackAdapterInstalled();
-    
-    // Check elevation
-    caps.elevated_privileges = IsRunningAsAdministrator();
-    
-    return caps;
+WindowsCapabilityDetector::WinRTCapabilities
+WindowsCapabilityDetector::DetectWinRTCapabilities() {
+  WinRTCapabilities caps{};
+
+  // Check if WinRT can be initialized
+  caps.winrt_available = CanInitializeWinRT();
+
+  // Check Windows version for API availability
+  if (IsWindows10Version1607OrLater()) {
+    caps.mobile_hotspot_api_available = true;
+  }
+
+  // WiFi Direct is available on Windows 8+
+  if (IsWindows8OrGreater()) {
+    caps.wifi_direct_available = true;
+  }
+
+  // Check for loopback adapter
+  caps.loopback_adapter_installed = IsLoopbackAdapterInstalled();
+
+  // Check elevation
+  caps.elevated_privileges = IsRunningAsAdministrator();
+
+  return caps;
 }
 
 bool WindowsCapabilityDetector::IsWinRTAvailable() {
 #if defined(WINRT_BASE_H)
-    return true;
+  return true;
 #else
-    return false;
+  return false;
 #endif
 }
 
 bool WindowsCapabilityDetector::CanInitializeWinRT() {
 #if defined(WINRT_BASE_H)
-    try {
-        winrt::init_apartment();
-        return true;
-    } catch (...) {
-        return false;
-    }
-#else
-    // Try dynamic loading as fallback
-    HMODULE combase = LoadLibraryW(L"combase.dll");
-    if (combase) {
-        auto roInitialize = GetProcAddress(combase, "RoInitialize");
-        FreeLibrary(combase);
-        return roInitialize != nullptr;
-    }
+  try {
+    winrt::init_apartment();
+    return true;
+  } catch (...) {
     return false;
+  }
+#else
+  // Try dynamic loading as fallback
+  HMODULE combase = LoadLibraryW(L"combase.dll");
+  if (combase) {
+    auto roInitialize = GetProcAddress(combase, "RoInitialize");
+    FreeLibrary(combase);
+    return roInitialize != nullptr;
+  }
+  return false;
 #endif
 }
 
 bool WindowsCapabilityDetector::IsRunningAsAdministrator() {
-    BOOL isAdmin = FALSE;
-    PSID adminGroup = nullptr;
-    
-    SID_IDENTIFIER_AUTHORITY ntAuthority = SECURITY_NT_AUTHORITY;
-    if (AllocateAndInitializeSid(&ntAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID,
-                                 DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &adminGroup)) {
-        CheckTokenMembership(nullptr, adminGroup, &isAdmin);
-        FreeSid(adminGroup);
-    }
-    
-    return isAdmin != FALSE;
+  BOOL isAdmin = FALSE;
+  PSID adminGroup = nullptr;
+
+  SID_IDENTIFIER_AUTHORITY ntAuthority = SECURITY_NT_AUTHORITY;
+  if (AllocateAndInitializeSid(&ntAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID,
+                               DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0,
+                               &adminGroup)) {
+    CheckTokenMembership(nullptr, adminGroup, &isAdmin);
+    FreeSid(adminGroup);
+  }
+
+  return isAdmin != FALSE;
 }
 
 bool WindowsCapabilityDetector::RequestAdminPrivileges() {
-    if (IsRunningAsAdministrator()) {
-        return true;
-    }
-    
-    // Get current executable path
-    wchar_t exePath[MAX_PATH];
-    GetModuleFileNameW(nullptr, exePath, MAX_PATH);
-    
-    // Re-launch with elevation
-    SHELLEXECUTEINFOW sei = {};
-    sei.cbSize = sizeof(sei);
-    sei.lpVerb = L"runas";
-    sei.lpFile = exePath;
-    sei.nShow = SW_NORMAL;
-    
-    if (ShellExecuteExW(&sei)) {
-        // Original process should exit after launching elevated version
-        return false; // Caller should exit
-    }
-    
-    return false;
+  if (IsRunningAsAdministrator()) {
+    return true;
+  }
+
+  // Get current executable path
+  wchar_t exePath[MAX_PATH];
+  GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+
+  // Re-launch with elevation
+  SHELLEXECUTEINFOW sei = {};
+  sei.cbSize = sizeof(sei);
+  sei.lpVerb = L"runas";
+  sei.lpFile = exePath;
+  sei.nShow = SW_NORMAL;
+
+  if (ShellExecuteExW(&sei)) {
+    // Original process should exit after launching elevated version
+    return false; // Caller should exit
+  }
+
+  return false;
 }
 
 bool WindowsCapabilityDetector::HasWiFiAdapter() {
-    ULONG bufferSize = 0;
-    GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr, &bufferSize);
-    
-    std::vector<BYTE> buffer(bufferSize);
-    PIP_ADAPTER_ADDRESSES addresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
-    
-    if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &bufferSize) == NO_ERROR) {
-        for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter; adapter = adapter->Next) {
-            if (adapter->IfType == IF_TYPE_IEEE80211 && adapter->OperStatus == IfOperStatusUp) {
-                return true;
-            }
-        }
+  PIP_ADAPTER_ADDRESSES addresses = GetCachedAdapters();
+  for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter;
+       adapter = adapter->Next) {
+    if (adapter->IfType == IF_TYPE_IEEE80211 &&
+        adapter->OperStatus == IfOperStatusUp) {
+      return true;
     }
-    
-    return false;
+  }
+  return false;
 }
 
 bool WindowsCapabilityDetector::HasEthernetAdapter() {
-    ULONG bufferSize = 0;
-    GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr, &bufferSize);
-    
-    std::vector<BYTE> buffer(bufferSize);
-    PIP_ADAPTER_ADDRESSES addresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
-    
-    if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &bufferSize) == NO_ERROR) {
-        for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter; adapter = adapter->Next) {
-            if (adapter->IfType == IF_TYPE_ETHERNET_CSMACD && adapter->OperStatus == IfOperStatusUp) {
-                return true;
-            }
-        }
+  PIP_ADAPTER_ADDRESSES addresses = GetCachedAdapters();
+  for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter;
+       adapter = adapter->Next) {
+    if (adapter->IfType == IF_TYPE_ETHERNET_CSMACD &&
+        adapter->OperStatus == IfOperStatusUp) {
+      return true;
     }
-    
-    return false;
+  }
+  return false;
+}
+
+void WindowsCapabilityDetector::InvalidateNetworkAdapterCache() {
+  std::lock_guard<std::mutex> lock(g_adapter_cache.mutex);
+  g_adapter_cache.buffer.clear();
+  g_adapter_cache.buffer.shrink_to_fit();
+  g_adapter_cache.addresses = nullptr;
+  g_adapter_cache.initialized = false;
 }
 
 bool WindowsCapabilityDetector::HasInternetConnection() {
 #if defined(WINRT_BASE_H)
-    try {
-        using namespace winrt::Windows::Networking::Connectivity;
-        auto profile = NetworkInformation::GetInternetConnectionProfile();
-        return profile != nullptr;
-    } catch (...) {
-        // Fallback to WinAPI method
-    }
+  try {
+    using namespace winrt::Windows::Networking::Connectivity;
+    auto profile = NetworkInformation::GetInternetConnectionProfile();
+    return profile != nullptr;
+  } catch (...) {
+    // Fallback to WinAPI method
+  }
 #endif
-    
-    // Fallback: Try to resolve a well-known host
-    WSADATA wsaData;
-    if (WSAStartup(MAKEWORD(2, 2), &wsaData) == 0) {
-        struct hostent* host = gethostbyname("dns.google");
-        WSACleanup();
-        return host != nullptr;
-    }
-    
-    return false;
+
+  // Fallback: Try to resolve a well-known host
+  WSADATA wsaData;
+  if (WSAStartup(MAKEWORD(2, 2), &wsaData) == 0) {
+    struct hostent *host = gethostbyname("dns.google");
+    WSACleanup();
+    return host != nullptr;
+  }
+
+  return false;
 }
 
 bool WindowsCapabilityDetector::IsLoopbackAdapterInstalled() {
-    ULONG bufferSize = 0;
-    GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr, &bufferSize);
-    
-    std::vector<BYTE> buffer(bufferSize);
-    PIP_ADAPTER_ADDRESSES addresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
-    
-    if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &bufferSize) == NO_ERROR) {
-        for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter; adapter = adapter->Next) {
-            // Check for Microsoft Loopback Adapter
-            std::wstring description(adapter->Description);
-            if (description.find(L"Microsoft") != std::wstring::npos && 
-                description.find(L"Loopback") != std::wstring::npos) {
-                return true;
-            }
-        }
+  ULONG bufferSize = 0;
+  GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr,
+                       &bufferSize);
+
+  std::vector<BYTE> buffer(bufferSize);
+  PIP_ADAPTER_ADDRESSES addresses =
+      reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
+
+  if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
+                           addresses, &bufferSize) == NO_ERROR) {
+    for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter;
+         adapter = adapter->Next) {
+      // Check for Microsoft Loopback Adapter
+      std::wstring description(adapter->Description);
+      if (description.find(L"Microsoft") != std::wstring::npos &&
+          description.find(L"Loopback") != std::wstring::npos) {
+        return true;
+      }
     }
-    
-    return false;
+  }
+
+  return false;
 }
 
 std::optional<std::string> WindowsCapabilityDetector::GetLoopbackAdapterGuid() {
-    ULONG bufferSize = 0;
-    GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr, &bufferSize);
-    
-    std::vector<BYTE> buffer(bufferSize);
-    PIP_ADAPTER_ADDRESSES addresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
-    
-    if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, addresses, &bufferSize) == NO_ERROR) {
-        for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter; adapter = adapter->Next) {
-            std::wstring description(adapter->Description);
-            if (description.find(L"Microsoft") != std::wstring::npos && 
-                description.find(L"Loopback") != std::wstring::npos) {
-                // Convert adapter name (GUID) to string
-                std::wstring guidStr(adapter->AdapterName);
-                std::string result(guidStr.begin(), guidStr.end());
-                return result;
-            }
-        }
+  ULONG bufferSize = 0;
+  GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, nullptr,
+                       &bufferSize);
+
+  std::vector<BYTE> buffer(bufferSize);
+  PIP_ADAPTER_ADDRESSES addresses =
+      reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
+
+  if (GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
+                           addresses, &bufferSize) == NO_ERROR) {
+    for (PIP_ADAPTER_ADDRESSES adapter = addresses; adapter;
+         adapter = adapter->Next) {
+      std::wstring description(adapter->Description);
+      if (description.find(L"Microsoft") != std::wstring::npos &&
+          description.find(L"Loopback") != std::wstring::npos) {
+        // Convert adapter name (GUID) to string
+        std::wstring guidStr(adapter->AdapterName);
+        std::string result(guidStr.begin(), guidStr.end());
+        return result;
+      }
     }
-    
-    return std::nullopt;
+  }
+
+  return std::nullopt;
 }
 
 bool WindowsCapabilityDetector::InstallLoopbackAdapter() {
-    if (!IsRunningAsAdministrator()) {
-        return false;
-    }
-    
-    // Use devcon or pnputil to install Microsoft Loopback Adapter
-    // This requires the hdwwiz.exe (Add Hardware Wizard)
-    SHELLEXECUTEINFOW sei = {};
-    sei.cbSize = sizeof(sei);
-    sei.lpVerb = L"runas";
-    sei.lpFile = L"hdwwiz.exe";
-    sei.lpParameters = L"/a /m";
-    sei.nShow = SW_HIDE;
-    sei.fMask = SEE_MASK_NOCLOSEPROCESS;
-    
-    if (ShellExecuteExW(&sei)) {
-        WaitForSingleObject(sei.hProcess, INFINITE);
-        DWORD exitCode;
-        GetExitCodeProcess(sei.hProcess, &exitCode);
-        CloseHandle(sei.hProcess);
-        return exitCode == 0;
-    }
-    
+  if (!IsRunningAsAdministrator()) {
     return false;
+  }
+
+  // Use devcon or pnputil to install Microsoft Loopback Adapter
+  // This requires the hdwwiz.exe (Add Hardware Wizard)
+  SHELLEXECUTEINFOW sei = {};
+  sei.cbSize = sizeof(sei);
+  sei.lpVerb = L"runas";
+  sei.lpFile = L"hdwwiz.exe";
+  sei.lpParameters = L"/a /m";
+  sei.nShow = SW_HIDE;
+  sei.fMask = SEE_MASK_NOCLOSEPROCESS;
+
+  if (ShellExecuteExW(&sei)) {
+    WaitForSingleObject(sei.hProcess, INFINITE);
+    DWORD exitCode;
+    GetExitCodeProcess(sei.hProcess, &exitCode);
+    CloseHandle(sei.hProcess);
+    return exitCode == 0;
+  }
+
+  return false;
 }
 
 bool WindowsCapabilityDetector::IsMobileHotspotSupported() {
-    if (!IsWindows10Version1607OrLater()) {
-        return false;
-    }
-    
-#if defined(WINRT_BASE_H)
-    try {
-        using namespace winrt::Windows::Networking::NetworkOperators;
-        using namespace winrt::Windows::Networking::Connectivity;
-        
-        // Check if we can get an internet connection profile
-        auto profile = NetworkInformation::GetInternetConnectionProfile();
-        if (!profile) {
-            // No internet connection - might still work with loopback
-            return IsLoopbackAdapterInstalled();
-        }
-        
-        // Try to create tethering manager
-        auto manager = NetworkOperatorTetheringManager::CreateFromConnectionProfile(profile);
-        return manager != nullptr;
-    } catch (...) {
-        return false;
-    }
-#else
+  if (!IsWindows10Version1607OrLater()) {
     return false;
+  }
+
+#if defined(WINRT_BASE_H)
+  try {
+    using namespace winrt::Windows::Networking::NetworkOperators;
+    using namespace winrt::Windows::Networking::Connectivity;
+
+    // Check if we can get an internet connection profile
+    auto profile = NetworkInformation::GetInternetConnectionProfile();
+    if (!profile) {
+      // No internet connection - might still work with loopback
+      return IsLoopbackAdapterInstalled();
+    }
+
+    // Try to create tethering manager
+    auto manager =
+        NetworkOperatorTetheringManager::CreateFromConnectionProfile(profile);
+    return manager != nullptr;
+  } catch (...) {
+    return false;
+  }
+#else
+  return false;
 #endif
 }
 
 bool WindowsCapabilityDetector::IsMobileHotspotEnabled() {
 #if defined(WINRT_BASE_H)
-    try {
-        using namespace winrt::Windows::Networking::NetworkOperators;
-        using namespace winrt::Windows::Networking::Connectivity;
-        
-        auto profile = NetworkInformation::GetInternetConnectionProfile();
-        if (!profile) {
-            return false;
-        }
-        
-        auto manager = NetworkOperatorTetheringManager::CreateFromConnectionProfile(profile);
-        if (manager) {
-            return manager.TetheringOperationalState() == TetheringOperationalState::On;
-        }
-    } catch (...) {
-        // Ignore exceptions
+  try {
+    using namespace winrt::Windows::Networking::NetworkOperators;
+    using namespace winrt::Windows::Networking::Connectivity;
+
+    auto profile = NetworkInformation::GetInternetConnectionProfile();
+    if (!profile) {
+      return false;
     }
+
+    auto manager =
+        NetworkOperatorTetheringManager::CreateFromConnectionProfile(profile);
+    if (manager) {
+      return manager.TetheringOperationalState() ==
+             TetheringOperationalState::On;
+    }
+  } catch (...) {
+    // Ignore exceptions
+  }
 #endif
-    return false;
+  return false;
 }
 
 bool WindowsCapabilityDetector::CanUseMobileHotspotWithoutInternet() {
-    return IsLoopbackAdapterInstalled() && IsMobileHotspotSupported();
+  return IsLoopbackAdapterInstalled() && IsMobileHotspotSupported();
 }
 
 bool WindowsCapabilityDetector::IsWiFiDirectSupported() {
-    // WiFi Direct requires Windows 8+ and a compatible WiFi adapter
-    return IsWindows8OrGreater() && HasWiFiAdapter();
+  // WiFi Direct requires Windows 8+ and a compatible WiFi adapter
+  return IsWindows8OrGreater() && HasWiFiAdapter();
 }
 
 bool WindowsCapabilityDetector::IsWiFiDirectEnabled() {
-    // This would require checking WlanHostedNetwork status or WiFi Direct API
-    // For now, just check if the service is running
-    SC_HANDLE scManager = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
-    if (scManager) {
-        SC_HANDLE service = OpenServiceW(scManager, L"WlanSvc", SERVICE_QUERY_STATUS);
-        if (service) {
-            SERVICE_STATUS status;
-            if (QueryServiceStatus(service, &status)) {
-                CloseServiceHandle(service);
-                CloseServiceHandle(scManager);
-                return status.dwCurrentState == SERVICE_RUNNING;
-            }
-            CloseServiceHandle(service);
-        }
+  // This would require checking WlanHostedNetwork status or WiFi Direct API
+  // For now, just check if the service is running
+  SC_HANDLE scManager = OpenSCManager(nullptr, nullptr, SC_MANAGER_CONNECT);
+  if (scManager) {
+    SC_HANDLE service =
+        OpenServiceW(scManager, L"WlanSvc", SERVICE_QUERY_STATUS);
+    if (service) {
+      SERVICE_STATUS status;
+      if (QueryServiceStatus(service, &status)) {
+        CloseServiceHandle(service);
         CloseServiceHandle(scManager);
+        return status.dwCurrentState == SERVICE_RUNNING;
+      }
+      CloseServiceHandle(service);
     }
-    return false;
+    CloseServiceHandle(scManager);
+  }
+  return false;
 }
 
-WindowsCapabilityDetector::RecommendedMode WindowsCapabilityDetector::GetRecommendedMode() {
-    auto caps = DetectWinRTCapabilities();
-    
-    // First choice: Mobile Hotspot with internet
-    if (caps.mobile_hotspot_api_available && HasInternetConnection()) {
-        return RecommendedMode::MobileHotspot;
-    }
-    
-    // Second choice: Mobile Hotspot with loopback adapter
-    if (caps.mobile_hotspot_api_available && caps.loopback_adapter_installed) {
-        return RecommendedMode::MobileHotspotWithLoopback;
-    }
-    
-    // Third choice: WiFi Direct
-    if (caps.wifi_direct_available && HasWiFiAdapter()) {
-        return RecommendedMode::WiFiDirect;
-    }
-    
-    // Fourth choice: Fall back to Internet multiplayer
-    if (HasInternetConnection()) {
-        return RecommendedMode::InternetMultiplayer;
-    }
-    
-    // No suitable mode available
-    return RecommendedMode::NotSupported;
+WindowsCapabilityDetector::RecommendedMode
+WindowsCapabilityDetector::GetRecommendedMode() {
+  auto caps = DetectWinRTCapabilities();
+
+  // First choice: Mobile Hotspot with internet
+  if (caps.mobile_hotspot_api_available && HasInternetConnection()) {
+    return RecommendedMode::MobileHotspot;
+  }
+
+  // Second choice: Mobile Hotspot with loopback adapter
+  if (caps.mobile_hotspot_api_available && caps.loopback_adapter_installed) {
+    return RecommendedMode::MobileHotspotWithLoopback;
+  }
+
+  // Third choice: WiFi Direct
+  if (caps.wifi_direct_available && HasWiFiAdapter()) {
+    return RecommendedMode::WiFiDirect;
+  }
+
+  // Fourth choice: Fall back to Internet multiplayer
+  if (HasInternetConnection()) {
+    return RecommendedMode::InternetMultiplayer;
+  }
+
+  // No suitable mode available
+  return RecommendedMode::NotSupported;
 }
 
-std::string WindowsCapabilityDetector::GetRecommendedModeDescription(RecommendedMode mode) {
-    switch (mode) {
-    case RecommendedMode::MobileHotspot:
-        return "Mobile Hotspot (Recommended) - Create a local wireless network for nearby devices";
-    case RecommendedMode::MobileHotspotWithLoopback:
-        return "Mobile Hotspot with Loopback Adapter - Create a local network without internet";
-    case RecommendedMode::WiFiDirect:
-        return "WiFi Direct - Direct device-to-device connection";
-    case RecommendedMode::InternetMultiplayer:
-        return "Internet Multiplayer - Play with others over the internet";
-    case RecommendedMode::NotSupported:
-        return "No supported multiplayer mode available on this system";
-    default:
-        return "Unknown mode";
-    }
+std::string
+WindowsCapabilityDetector::GetRecommendedModeDescription(RecommendedMode mode) {
+  switch (mode) {
+  case RecommendedMode::MobileHotspot:
+    return "Mobile Hotspot (Recommended) - Create a local wireless network for "
+           "nearby devices";
+  case RecommendedMode::MobileHotspotWithLoopback:
+    return "Mobile Hotspot with Loopback Adapter - Create a local network "
+           "without internet";
+  case RecommendedMode::WiFiDirect:
+    return "WiFi Direct - Direct device-to-device connection";
+  case RecommendedMode::InternetMultiplayer:
+    return "Internet Multiplayer - Play with others over the internet";
+  case RecommendedMode::NotSupported:
+    return "No supported multiplayer mode available on this system";
+  default:
+    return "Unknown mode";
+  }
 }
 
 std::string WindowsCapabilityDetector::GetDiagnosticReport() {
-    std::stringstream report;
-    
-    report << "=== Windows Capability Diagnostic Report ===\n\n";
-    
-    // Windows version
-    auto version = GetWindowsVersion();
-    report << "Windows Version: " << version.edition << " (" << version.version_string << ")\n";
-    report << "Build Number: " << version.build_number << "\n\n";
-    
-    // WinRT capabilities
-    auto caps = DetectWinRTCapabilities();
-    report << "WinRT Capabilities:\n";
-    report << "  WinRT Available: " << (caps.winrt_available ? "Yes" : "No") << "\n";
-    report << "  Mobile Hotspot API: " << (caps.mobile_hotspot_api_available ? "Yes" : "No") << "\n";
-    report << "  WiFi Direct API: " << (caps.wifi_direct_available ? "Yes" : "No") << "\n";
-    report << "  Loopback Adapter: " << (caps.loopback_adapter_installed ? "Installed" : "Not Installed") << "\n";
-    report << "  Admin Privileges: " << (caps.elevated_privileges ? "Yes" : "No") << "\n\n";
-    
-    // Network adapters
-    report << "Network Adapters:\n";
-    report << "  WiFi Adapter: " << (HasWiFiAdapter() ? "Present" : "Not Found") << "\n";
-    report << "  Ethernet Adapter: " << (HasEthernetAdapter() ? "Present" : "Not Found") << "\n";
-    report << "  Internet Connection: " << (HasInternetConnection() ? "Available" : "Not Available") << "\n\n";
-    
-    // Feature support
-    report << "Feature Support:\n";
-    report << "  Mobile Hotspot: " << (IsMobileHotspotSupported() ? "Supported" : "Not Supported") << "\n";
-    report << "  Mobile Hotspot Active: " << (IsMobileHotspotEnabled() ? "Yes" : "No") << "\n";
-    report << "  WiFi Direct: " << (IsWiFiDirectSupported() ? "Supported" : "Not Supported") << "\n\n";
-    
-    // Recommendation
-    auto mode = GetRecommendedMode();
-    report << "Recommended Mode: " << GetRecommendedModeDescription(mode) << "\n";
-    
-    return report.str();
+  std::stringstream report;
+
+  report << "=== Windows Capability Diagnostic Report ===\n\n";
+
+  // Windows version
+  auto version = GetWindowsVersion();
+  report << "Windows Version: " << version.edition << " ("
+         << version.version_string << ")\n";
+  report << "Build Number: " << version.build_number << "\n\n";
+
+  // WinRT capabilities
+  auto caps = DetectWinRTCapabilities();
+  report << "WinRT Capabilities:\n";
+  report << "  WinRT Available: " << (caps.winrt_available ? "Yes" : "No")
+         << "\n";
+  report << "  Mobile Hotspot API: "
+         << (caps.mobile_hotspot_api_available ? "Yes" : "No") << "\n";
+  report << "  WiFi Direct API: " << (caps.wifi_direct_available ? "Yes" : "No")
+         << "\n";
+  report << "  Loopback Adapter: "
+         << (caps.loopback_adapter_installed ? "Installed" : "Not Installed")
+         << "\n";
+  report << "  Admin Privileges: " << (caps.elevated_privileges ? "Yes" : "No")
+         << "\n\n";
+
+  // Network adapters
+  report << "Network Adapters:\n";
+  report << "  WiFi Adapter: " << (HasWiFiAdapter() ? "Present" : "Not Found")
+         << "\n";
+  report << "  Ethernet Adapter: "
+         << (HasEthernetAdapter() ? "Present" : "Not Found") << "\n";
+  report << "  Internet Connection: "
+         << (HasInternetConnection() ? "Available" : "Not Available") << "\n\n";
+
+  // Feature support
+  report << "Feature Support:\n";
+  report << "  Mobile Hotspot: "
+         << (IsMobileHotspotSupported() ? "Supported" : "Not Supported")
+         << "\n";
+  report << "  Mobile Hotspot Active: "
+         << (IsMobileHotspotEnabled() ? "Yes" : "No") << "\n";
+  report << "  WiFi Direct: "
+         << (IsWiFiDirectSupported() ? "Supported" : "Not Supported") << "\n\n";
+
+  // Recommendation
+  auto mode = GetRecommendedMode();
+  report << "Recommended Mode: " << GetRecommendedModeDescription(mode) << "\n";
+
+  return report.str();
 }
 
 } // namespace Core::Multiplayer::ModelB::Windows

--- a/src/core/multiplayer/model_b/platform/windows/windows_capability_detector.h
+++ b/src/core/multiplayer/model_b/platform/windows/windows_capability_detector.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <string>
 #include <optional>
+#include <string>
 
 namespace Core::Multiplayer::ModelB::Windows {
 
@@ -14,68 +14,71 @@ namespace Core::Multiplayer::ModelB::Windows {
  */
 class WindowsCapabilityDetector {
 public:
-    struct WindowsVersionInfo {
-        uint32_t major_version;
-        uint32_t minor_version;
-        uint32_t build_number;
-        std::string version_string;
-        std::string edition;
-    };
+  struct WindowsVersionInfo {
+    uint32_t major_version;
+    uint32_t minor_version;
+    uint32_t build_number;
+    std::string version_string;
+    std::string edition;
+  };
 
-    struct WinRTCapabilities {
-        bool winrt_available;
-        bool mobile_hotspot_api_available;
-        bool wifi_direct_available;
-        bool loopback_adapter_installed;
-        bool elevated_privileges;
-    };
+  struct WinRTCapabilities {
+    bool winrt_available;
+    bool mobile_hotspot_api_available;
+    bool wifi_direct_available;
+    bool loopback_adapter_installed;
+    bool elevated_privileges;
+  };
 
-    // Version detection
-    static WindowsVersionInfo GetWindowsVersion();
-    static bool IsWindows10OrLater();
-    static bool IsWindows10Version1607OrLater(); // Required for NetworkOperatorTetheringManager
-    
-    // WinRT capability detection
-    static WinRTCapabilities DetectWinRTCapabilities();
-    static bool IsWinRTAvailable();
-    static bool CanInitializeWinRT();
-    
-    // Admin/elevation detection
-    static bool IsRunningAsAdministrator();
-    static bool RequestAdminPrivileges();
-    
-    // Network adapter detection
-    static bool HasWiFiAdapter();
-    static bool HasEthernetAdapter();
-    static bool HasInternetConnection();
-    
-    // Loopback adapter detection and installation
-    static bool IsLoopbackAdapterInstalled();
-    static std::optional<std::string> GetLoopbackAdapterGuid();
-    static bool InstallLoopbackAdapter();
-    
-    // Mobile Hotspot specific checks
-    static bool IsMobileHotspotSupported();
-    static bool IsMobileHotspotEnabled();
-    static bool CanUseMobileHotspotWithoutInternet(); // Loopback workaround
-    
-    // WiFi Direct specific checks
-    static bool IsWiFiDirectSupported();
-    static bool IsWiFiDirectEnabled();
-    
-    // Get recommended fallback mode based on capabilities
-    enum class RecommendedMode {
-        MobileHotspot,
-        MobileHotspotWithLoopback,
-        WiFiDirect,
-        InternetMultiplayer,
-        NotSupported
-    };
-    static RecommendedMode GetRecommendedMode();
-    static std::string GetRecommendedModeDescription(RecommendedMode mode);
-    
-    // Diagnostic information
-    static std::string GetDiagnosticReport();
+  // Version detection
+  static WindowsVersionInfo GetWindowsVersion();
+  static bool IsWindows10OrLater();
+  static bool
+  IsWindows10Version1607OrLater(); // Required for
+                                   // NetworkOperatorTetheringManager
+
+  // WinRT capability detection
+  static WinRTCapabilities DetectWinRTCapabilities();
+  static bool IsWinRTAvailable();
+  static bool CanInitializeWinRT();
+
+  // Admin/elevation detection
+  static bool IsRunningAsAdministrator();
+  static bool RequestAdminPrivileges();
+
+  // Network adapter detection
+  static bool HasWiFiAdapter();
+  static bool HasEthernetAdapter();
+  static bool HasInternetConnection();
+  static void InvalidateNetworkAdapterCache();
+
+  // Loopback adapter detection and installation
+  static bool IsLoopbackAdapterInstalled();
+  static std::optional<std::string> GetLoopbackAdapterGuid();
+  static bool InstallLoopbackAdapter();
+
+  // Mobile Hotspot specific checks
+  static bool IsMobileHotspotSupported();
+  static bool IsMobileHotspotEnabled();
+  static bool CanUseMobileHotspotWithoutInternet(); // Loopback workaround
+
+  // WiFi Direct specific checks
+  static bool IsWiFiDirectSupported();
+  static bool IsWiFiDirectEnabled();
+
+  // Get recommended fallback mode based on capabilities
+  enum class RecommendedMode {
+    MobileHotspot,
+    MobileHotspotWithLoopback,
+    WiFiDirect,
+    InternetMultiplayer,
+    NotSupported
+  };
+  static RecommendedMode GetRecommendedMode();
+  static std::string GetRecommendedModeDescription(RecommendedMode mode);
+
+  // Diagnostic information
+  static std::string GetDiagnosticReport();
 };
 
 } // namespace Core::Multiplayer::ModelB::Windows


### PR DESCRIPTION
## Summary
- add thread-safe cache for GetAdaptersAddresses results
- reuse cached adapters for WiFi/Ethernet detection
- expose invalidation helper to refresh adapter data after system changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68960a0db488832282d08f58cfacd689