### PR TITLE
Map additional LDN network fields for LDN translator

### DIFF
--- a/docs/developer-guide/api-reference.md
+++ b/docs/developer-guide/api-reference.md
@@ -277,6 +277,34 @@ namespace Core::Multiplayer {
 }
 ```
 
+`TypeTranslator` operates on an internal representation of network details. The
+`InternalNetworkInfo` structure now exposes additional fields required by games
+that perform strict compatibility checks:
+
+```cpp
+struct InternalNetworkInfo {
+    std::string network_name;
+    std::vector<uint8_t> network_id;
+    std::vector<uint8_t> session_id;
+    uint64_t local_communication_id;
+    uint16_t channel;
+    uint8_t node_count;
+    uint8_t node_count_max;
+    int8_t link_level;
+    uint8_t network_mode;           // 0=None, 1=General, 2=LDN, 3=All
+    std::vector<InternalNodeInfo> nodes;
+    std::vector<uint8_t> advertise_data;
+    bool has_password;
+    std::vector<uint8_t> security_parameter;
+    uint8_t security_mode;          // 0=All, 1=Retail, 2=Debug
+    uint16_t local_communication_version; // Required by titles like Splatoon 3
+};
+```
+
+`ToLdnNetworkInfo` and `FromLdnNetworkInfo` map these fields to the underlying
+LDN structures, preserving security mode, local communication version and other
+security parameters.
+
 ## Backend Interface API
 
 ### IMultiplayerBackend Interface

--- a/src/core/multiplayer/type_translator.h
+++ b/src/core/multiplayer/type_translator.h
@@ -25,6 +25,15 @@ namespace Core::Multiplayer::HLE {
 /**
  * Internal Multiplayer Types - Minimal definitions for type conversion
  */
+struct InternalNodeInfo {
+    uint8_t node_id;
+    std::string user_name;
+    std::array<uint8_t, 6> mac_address{};
+    std::array<uint8_t, 4> ipv4_address{};
+    bool is_connected;
+    uint16_t local_communication_version;
+};
+
 struct InternalNetworkInfo {
     std::string network_name;
     std::vector<uint8_t> network_id;
@@ -35,17 +44,11 @@ struct InternalNetworkInfo {
     uint8_t node_count_max;
     int8_t link_level;  // Signal strength
     uint8_t network_mode;  // 0=None, 1=General, 2=LDN, 3=All
+    std::vector<InternalNodeInfo> nodes;
     std::vector<uint8_t> advertise_data;
     bool has_password;
     std::vector<uint8_t> security_parameter;
-};
-
-struct InternalNodeInfo {
-    uint8_t node_id;
-    std::string user_name;
-    std::array<uint8_t, 6> mac_address{};
-    std::array<uint8_t, 4> ipv4_address{};
-    bool is_connected;
+    uint8_t security_mode;  // 0=All, 1=Retail, 2=Debug
     uint16_t local_communication_version;
 };
 

--- a/tests/integration/game_specific/test_splatoon_multiplayer.cpp
+++ b/tests/integration/game_specific/test_splatoon_multiplayer.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Sudachi Emulator Project
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include "../../../src/core/multiplayer/type_translator.cpp"
+
+using namespace Core::Multiplayer::HLE;
+
+// Splatoon 3 requires correct security mode and local communication version
+TEST(SplatoonMultiplayerTest, MapsSecurityAndVersionFields) {
+    ConcreteTypeTranslator translator;
+
+    InternalNetworkInfo internal{};
+    internal.network_name = "Splatoon3";
+    internal.local_communication_id = 0x12345678ULL;
+    internal.channel = 1;
+    internal.node_count = 1;
+    internal.node_count_max = 8;
+    internal.link_level = 0;
+    internal.network_mode = static_cast<uint8_t>(Service::LDN::PackedNetworkType::Ldn);
+    internal.session_id = std::vector<uint8_t>(sizeof(Service::LDN::SessionId), 0x42);
+    internal.security_mode = static_cast<uint8_t>(Service::LDN::SecurityMode::Retail);
+    internal.local_communication_version = 0x0102;
+    internal.nodes.push_back({0, "Host", {0,0,0,0,0,0}, {0,0,0,0}, true, internal.local_communication_version});
+
+    auto ldn = translator.ToLdnNetworkInfo(internal);
+    EXPECT_EQ(ldn.ldn.security_mode, Service::LDN::SecurityMode::Retail);
+    EXPECT_EQ(ldn.common.network_type, Service::LDN::PackedNetworkType::Ldn);
+    EXPECT_EQ(ldn.ldn.nodes[0].local_communication_version,
+              static_cast<int16_t>(internal.local_communication_version));
+
+    auto roundtrip = translator.FromLdnNetworkInfo(ldn);
+    EXPECT_EQ(roundtrip.security_mode, internal.security_mode);
+    EXPECT_EQ(roundtrip.network_mode, internal.network_mode);
+    EXPECT_EQ(roundtrip.local_communication_version, internal.local_communication_version);
+}
+


### PR DESCRIPTION
## Summary
- map security mode, network mode, session id, node list, and local communication version in TypeTranslator's LDN network conversions
- describe new InternalNetworkInfo fields in developer API docs
- add Splatoon-specific test covering security and version fields

## Testing
- `pre-commit run --files src/core/multiplayer/type_translator.h src/core/multiplayer/type_translator.cpp tests/integration/game_specific/test_splatoon_multiplayer.cpp docs/developer-guide/api-reference.md`
- `g++ -std=c++17 tests/integration/game_specific/test_splatoon_multiplayer.cpp -lgtest -lpthread -o /tmp/test_splatoon` *(fails: sudachi/src/core/hle/service/ldn/ldn_types.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68960a0ee9448322894647d057f57077